### PR TITLE
Update first_app.md & webpack-configuration.md - ES Module syntax not supported

### DIFF
--- a/src/pages/getting_started/first_app.md
+++ b/src/pages/getting_started/first_app.md
@@ -347,6 +347,7 @@ You should be able to see these folders and files in your project:
     - Under each folder, you should be able to see both the actions and the frontend code when application. In addition, you should be able to see `ext.config.yaml`. This file contains all the action and extension configuration for the extension point where it's located. This individual configuration allows for more flexibility in defining and managing individual extension points. You can see that this file is also imported to `app.config.yaml` as that's the master config file.
     - The action definition in this file shoud adhere to the [OpenWhisk deployment YAML specification](https://github.com/apache/openwhisk-wskdeploy/tree/master/specification#package-specification).
     - Once defined, the [CLI](https://github.com/adobe/aio-cli) use this file to deploy or redeploy actions. You might see values like `$CUSTOMER_PROFILE_TENANT` listed under environments in this file. These are environment variables that you can define in your `.env` file.
+    - The generated actions use CommonJS syntax. **ES Module syntax is not supported by App Builder**.
 1. `test`: this folder is intended for back-end action unit tests and integration tests
 1. `e2e`: this folder is intended for  end-to-end tests
 1. `app.config.yaml`: this is the master configuration file. It follows the same principle as the individual `ext.config.yaml`, and compiles these individual file into one comprehensive config upon application build.

--- a/src/pages/guides/configuration/webpack-configuration.md
+++ b/src/pages/guides/configuration/webpack-configuration.md
@@ -16,6 +16,10 @@ folders.
 
 If you want to specify a Webpack configuration for an entire project, place the `*webpack-config.js` file in the root directory of your project.
 
+### ES Module Syntax 
+
+App Builder currently does not support ES Module syntax. This file must be written in CommonJS otherwise failures will occur at build time. 
+
 ## Configuration Types
 
 App Builder supports exporting the following configuration types in `*webpack-config.js`.


### PR DESCRIPTION
## Description

* Specify ES Module syntax is not supported in first app guide 
* Specify ES Module syntax is not supported in webpack configuration guide

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
