### PR TITLE
add packaging guide for `aio app pack`

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -98,6 +98,10 @@ module.exports = {
           {
             "title": "Event hooks for App Builder Applications",
             "path": "guides/app-hooks.md"
+          },
+          {
+            "title": "Packaging for Developer Distribution",
+            "path": "guides/packaging.md"
           }
         ]
       },

--- a/src/pages/guides/packaging.md
+++ b/src/pages/guides/packaging.md
@@ -9,7 +9,7 @@ keywords:
 
 # Packaging for Developer Distribution
 
-To get your App Buikder app listed for [Adobe Developer Distribution](https://developer.adobe.com/developer-distribution/), you will need to package it.
+To get your App Builder app listed for [Adobe Developer Distribution](https://developer.adobe.com/developer-distribution/), you will need to package it.
 
 The `aio app pack` command will verify and bundle your app. In the root of your app folder, run this command:
 

--- a/src/pages/guides/packaging.md
+++ b/src/pages/guides/packaging.md
@@ -1,0 +1,47 @@
+---
+keywords:
+  - Adobe I/O
+  - Extensibility
+  - ISV
+  - Developer Tooling
+---
+
+
+# App Builder Packaging for Developer Distribution
+
+To get your App Buikder app listed for [Adobe Developer Distribution](https://developer.adobe.com/developer-distribution/), you will need to package it.
+
+The `aio app pack` command will verify and bundle your app.
+
+In the root of your app folder, run this command:
+
+```sh
+aio app pack
+```
+
+After this command is run, you can find your app package in your app folder: `dist/app.zip`.
+
+## Hooks
+
+Two new [hooks](./app-hooks.md) have been added for this command, and will run and after the command is run:
+
+1. pre-pack
+2. post-pack
+
+Your hook handler function will be passed two items:
+
+1. `appConfig` (object) - this contains the config of the current application
+2. `artifactsFolder` (string) - this will be the location of the folder containing all the packaging artifacts that will be bundled
+
+## App Validation
+
+1. `app.config.yaml` 
+     - will be checked if it is in a valid format, and will show specific config errors for you to fix if necessary
+2. `package.json` version
+     - application version format must be `X.Y.Z`, where X, Y, and Z are non-negative integers
+3. files to be packaged. All the files in your app folder will be packaged EXCEPT:
+     - files specified in `.gitignore`
+     - files specified in `.npmignore`
+     - any `dist` folders
+     - any OS junk files (.DS_Store, thumbs.db, etc)
+4. event registrations will be validated (if any)

--- a/src/pages/guides/packaging.md
+++ b/src/pages/guides/packaging.md
@@ -17,24 +17,25 @@ The `aio app pack` command will verify and bundle your app. In the root of your 
 aio app pack
 ```
 
-After this command completes running, you can find your app package in your app folder: `dist/app.zip`.
+After this command completes running, you can find the app package in your app folder as: `dist/app.zip`.
 
 ## App Validation
 
 1. `app.config.yaml` 
-     - will be checked if it is in a valid format, and will show specific config errors for you to fix if necessary
+     - will be checked if it is in a valid format, and will show specific config errors for you to fix, if necessary
 2. `package.json` version
      - application version format must be `X.Y.Z`, where X, Y, and Z are non-negative integers
 3. files to be packaged. All the files in your app folder will be packaged EXCEPT:
      - files specified in `.gitignore`
      - files specified in `.npmignore`
      - any `dist` folders
+     - any dot files (.env, .gitignore, etc)
      - any OS junk files (.DS_Store, thumbs.db, etc)
 4. event registrations will be validated (if any)
 
 ## Hooks
 
-Two new [hooks](./app-hooks.md) have been added for this command, and will run and after the command is run:
+Two new [hooks](./app-hooks.md) have been added for this command, and will run before and after the command is run (respectively):
 
 1. pre-pack
 2. post-pack

--- a/src/pages/guides/packaging.md
+++ b/src/pages/guides/packaging.md
@@ -7,31 +7,17 @@ keywords:
 ---
 
 
-# App Builder Packaging for Developer Distribution
+# Packaging for Developer Distribution
 
 To get your App Buikder app listed for [Adobe Developer Distribution](https://developer.adobe.com/developer-distribution/), you will need to package it.
 
-The `aio app pack` command will verify and bundle your app.
-
-In the root of your app folder, run this command:
+The `aio app pack` command will verify and bundle your app. In the root of your app folder, run this command:
 
 ```sh
 aio app pack
 ```
 
-After this command is run, you can find your app package in your app folder: `dist/app.zip`.
-
-## Hooks
-
-Two new [hooks](./app-hooks.md) have been added for this command, and will run and after the command is run:
-
-1. pre-pack
-2. post-pack
-
-Your hook handler function will be passed two items:
-
-1. `appConfig` (object) - this contains the config of the current application
-2. `artifactsFolder` (string) - this will be the location of the folder containing all the packaging artifacts that will be bundled
+After this command completes running, you can find your app package in your app folder: `dist/app.zip`.
 
 ## App Validation
 
@@ -45,3 +31,15 @@ Your hook handler function will be passed two items:
      - any `dist` folders
      - any OS junk files (.DS_Store, thumbs.db, etc)
 4. event registrations will be validated (if any)
+
+## Hooks
+
+Two new [hooks](./app-hooks.md) have been added for this command, and will run and after the command is run:
+
+1. pre-pack
+2. post-pack
+
+Your hook handler function will be passed two items:
+
+1. `appConfig` (object) - this contains the config of the current application
+2. `artifactsFolder` (string) - this will be the location of the folder containing all the packaging artifacts that will be bundled


### PR DESCRIPTION
Packaging guide for the `aio app pack` command.
In the root of the Guides TOC.

## How Has This Been Tested?

- yarn install && yarn build && yarn serve
- observe the contents of the /guides/packaging link and test any links

## Screenshots (if appropriate):

<img width="1452" alt="2024-03-21_22-24-20" src="https://github.com/AdobeDocs/app-builder/assets/36107/8f13d14b-87c9-41ef-92d3-8cbb8fbef761">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
