### PR TITLE
Change --no-extensions to --standalone-app in docs

### DIFF
--- a/src/pages/resources/spectrum-intro/lesson4.md
+++ b/src/pages/resources/spectrum-intro/lesson4.md
@@ -12,7 +12,7 @@ title: 'Lesson 4: React Spectrum in App Builder'
 To initialize an App Builder app, let’s use the init command from the [CLI](https://github.com/adobe/aio-cli).
 
 ```bash
-aio app init my-app --no-extensions
+aio app init my-app --standalone-app
 ```
 
 You’re presented with a few options what you want your app to include (serverless actions, web UI assets, CI/CD pipeline). 


### PR DESCRIPTION
On version 10.3.2 the --no-extensions flag no longer exists. The output:
```
 ›   Error: Nonexistent flag: --no-extensions
 ›   See more help with --help
```

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
