### PR TITLE
docs: add interfaces index.md as table of contents for interface docs

### DIFF
--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/index.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/index.md
@@ -1,0 +1,32 @@
+---
+title: 'Adobe Experience Cloud App Builder: Interfaces Index'
+---
+
+# Interfaces Index
+
+This section provides an overview and quick navigation for all interfaces available in the Adobe Experience Cloud App Builder extensibility APIs. Each interface is documented in detail in its own file. Use this index to explore the available APIs and their capabilities.
+
+## Table of Contents
+
+| Interface | Description |
+|-----------|-------------|
+| [Modules](modules.md) | Entry point for accessing all major APIs: runtime, page, topbar, and user. |
+| [Runtime](runtime.md) | Provides unified-shell APIs and event handling for solution authors. |
+| [PageApi](page.pageapi.md) | Page-level APIs for controlling shell/page behavior and properties. |
+| [PageApiProperties](page.pageapiproperties.md) | Settable attributes for page-level APIs (e.g., title, favicon, modal). |
+| [ObjectWithHref](page.objectwithhref.md) | Represents a solution page by its URL (href). |
+| [ObjectWithPath](page.objectwithpath.md) | Represents a solution page by its relative path. |
+| [TopbarAPI](topbar.topbarapi.md) | APIs for customizing the Experience Cloud top bar. |
+| [TopbarAPIProperties](topbar.topbarapiproperties.md) | Settable attributes for the top bar (e.g., workspaces, solution info). |
+| [Solution](topbar.solution.md) | Attributes for the solution area in the top bar (icon, title, shortTitle). |
+| [Callback](topbar.callback.md) | Function signature for callback handlers (e.g., hero click, feedback). |
+| [CustomFeedbackConfig](topbar.customfeedbackconfig.md) | Configures a custom feedback button in the top bar. |
+| [CustomSearchConfig](topbar.customsearchconfig.md) | Configures a custom search button in the top bar. |
+| [ExternalFeedbackConfig](topbar.externalfeedbackconfig.md) | Configures an external feedback button in the top bar. |
+| [HelpCenterFeedbackConfig](topbar.helpcenterfeedbackconfig.md) | Configures a help center feedback button in the top bar. |
+| [UserAPI](user.userapi.md) | APIs for user information, authentication, and events. |
+| [UserInfo](user.userinfo.md) | Structure for user identity, org, and locale information. |
+
+---
+
+Return to the [Guides Index](../../../index.md). 


### PR DESCRIPTION
## Summary

This PR adds an `index.md` file to the `src/pages/guides/app_builder_guides/exc_app/interfaces/` directory, serving as a table of contents for all documented interfaces in the Adobe Experience Cloud App Builder extensibility APIs.

## Details

- Provides a brief introduction to the interfaces section.
- Includes a markdown table listing each interface with a short description and a direct link to its documentation.
- Improves discoverability and navigation for developers exploring available APIs.

## Motivation

Fixing 404s ahead of the migration to EDS and this was one that was found. 