### PR TITLE
docs: add instructions for opting out of default response headers via…

### DIFF
--- a/src/pages/guides/app_builder_guides/deployment/setting_response_headers.md
+++ b/src/pages/guides/app_builder_guides/deployment/setting_response_headers.md
@@ -54,6 +54,20 @@ application:
 
 Once headers are added, they can be deployed with the app using the `aio app:deploy` command. Note that the paths specified in rules are relative to the distributable folder created after the application build, and not to the application root.
 
+## Opting Out of Default Response Headers
+
+By default, App Builder may set certain response headers automatically for your web actions. If you want to take full control and override all default response headers with your own custom options, you must explicitly opt out of the defaults.
+
+To do this, update your web action with the `web-custom-options` annotation set to `true` using the CLI:
+
+```bash
+aio app action update <your-action-name> --web true -a web-custom-options true
+```
+
+Replace `<your-action-name>` with the name of your web action. This command ensures that only the response headers you define (for example, in your manifest or action code) will be applied, and no additional default headers will be set by App Builder.
+
+This is especially important if you require strict control over CORS, security, or other HTTP headers for your application's endpoints.
+
 ## Disallowed headers
 
 Developers may set any HTTP or custom response headers except those in the list below. If the listed headers are specified in the manifest, they will be ignored and not included in the response.


### PR DESCRIPTION
## Summary

This PR updates the "Setting Response Headers" documentation to include instructions for opting out of default response header options in App Builder web actions, as required by [IOEXT-1011](https://jira.corp.adobe.com/browse/IOEXT-1011).

## Details

- Adds a new section, "Opting Out of Default Response Headers," after the Example usage.
- Explains that users must explicitly set the `web-custom-options` annotation to `true` to override all default response headers.
- Provides the exact CLI command:
  ```
  aio app action update <your-action-name> --web true -a web-custom-options true
  ```