### PR TITLE
Update setup.md

### DIFF
--- a/src/pages/get_started/runtime_getting_started/setup.md
+++ b/src/pages/get_started/runtime_getting_started/setup.md
@@ -37,7 +37,8 @@ There are two ways to configure the `aio` CLI:
 
 ### Configure aio CLI
 
-The `aio` CLI will pick up credentials from an `.env` file in the current working directory.
+1. `aio app use <project configuration file location>.json`
+2. This will generate `.env` and `.aio` files in your current working directory.
 
 ## Test that the CLI is set up correctly
 

--- a/src/pages/get_started/runtime_getting_started/setup.md
+++ b/src/pages/get_started/runtime_getting_started/setup.md
@@ -23,6 +23,7 @@ In the Developer Console:
 * Create a new `Project`.
 * Select a workspace option, for example `Production`.
 * Click `Add service` and choose `Runtime`.
+** `Runtime` may be automatically included in your workspace.
 * Navigate back to `Workspace overview` page and click on the `Download all` button at the top of the page. This will download the configuration file for this project and workspace.
 * Open the configuration file in a text editor and search for the `runtime` > `namespaces` entry. Here you will find the namespace `name` and `auth` values you will use to configure the `aio` CLI. 
 


### PR DESCRIPTION
I tried following the setup but when I went to "add service" i could not click runtime.

![image](https://github.com/user-attachments/assets/80798862-e2de-4ac8-90ff-a922d20bda86)

I assume because now when you create a new "app builder" project this box is checked (bottom right) and so it's already included

![image](https://github.com/user-attachments/assets/94076f3f-ff84-4405-b9a3-4a7cb4bee20e)


I also noticed the instructions were sparse. It details creating an .env from the downloaded file, but it doesn't inform what keys/props should exist. I found in searching slack about `app use` and tried `aio app use <file>` and it generated the correct env and .aio files for me (I think).


