### PR TITLE
IOEXT-1320: Add prerequisites for aio app pack command

### DIFF
--- a/src/pages/guides/app_builder_guides/distribution.md
+++ b/src/pages/guides/app_builder_guides/distribution.md
@@ -267,6 +267,44 @@ Product version information can be found on [Adobe Experience League](https://ex
 
 Once an app is configured for public distribution, it can be packaged and uploaded to [Adobe Developer Distribution](https://developer.adobe.com/developer-distribution/). 
 
+#### Prerequisites
+
+Before running `aio app pack`, especially on a freshly checked-out project that hasn't been run before, you need to ensure the project is properly configured and bound to an App Builder workspace. The packaging command requires that your local project is connected to a workspace with the necessary APIs and credentials.
+
+If you're working with a newly cloned repository or a project that hasn't been set up yet, follow these steps:
+
+1. **Create an App Builder project** in the [Adobe Developer Console](https://developer.adobe.com/console)
+   
+2. **Add the required APIs** to your workspace in the Developer Console
+
+3. **Download the workspace configuration**
+   - In the Developer Console, navigate to your workspace
+   - Click "Download all" to get the `workspace.json` file
+
+4. **Bind your local project to the workspace**
+   ```sh
+   aio app use workspace.json
+   ```
+
+5. **Install dependencies**
+   ```sh
+   npm install
+   ```
+
+6. **Run the app at least once** to complete the configuration binding
+   ```sh
+   aio app run
+   ```
+   
+   Or alternatively:
+   ```sh
+   aio app dev
+   ```
+
+Once these steps are completed, your project will be properly configured and bound to the workspace, allowing you to successfully run the packaging command.
+
+#### Running the Pack Command
+
 The `aio app pack` command verifies and bundles applications for upload. In the root of your app folder, run:
 
 ```sh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Added Prerequisites section explaining setup steps for freshly cloned projects
- Documented required steps: console setup, workspace config, binding, and initial run
- Clarifies why aio app pack fails on new checkouts
- Addresses GitHub issue #400

<!--- Describe your changes in detail -->

IOEXT-1320

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Helping customers!

<!--- Why is this change required? What problem does it solve? -->



<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
