### PR TITLE
Fix App Builder navigation link to use absolute URL

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -3,7 +3,7 @@
 
 
 - pages:
-    - [App Builder](../)
+    - [App Builder](https://developer.adobe.com/app-builder/)
     - [Overview](intro_and_overview/index.md)
     - [Getting Started](get_started/index.md)
     - [Guides](guides/index.md)


### PR DESCRIPTION
Change the App Builder link in config.md from a relative path (../) to the absolute URL (https://developer.adobe.com/app-builder/)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
