### PR TITLE
Update typescript-app quickstart link to remove caveat

### DIFF
--- a/src/pages/guides/app_builder_guides/configuration/typescript-actions.md
+++ b/src/pages/guides/app_builder_guides/configuration/typescript-actions.md
@@ -86,7 +86,7 @@ For general Webpack constraints (immutable options, supported config formats, et
 
 ## Example project
 
-The [typescript-app quickstart](https://github.com/adobe/appbuilder-quickstarts/tree/master/typescript-app) demonstrates TypeScript in an App Builder project. Note that it uses a manual `tsc` compilation approach; the `ts-loader` method described on this page is a simpler alternative that avoids the need for a separate build step or duplicated source directories.
+The [typescript-app quickstart](https://github.com/adobe/appbuilder-quickstarts/tree/master/typescript-app) provides a complete working example of TypeScript Runtime actions using the `ts-loader` approach described on this page.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

- Remove the caveat on the TypeScript Actions page that warned the quickstart example uses a manual `tsc` approach

This is a follow-up to #521 (merged). The caveat is no longer needed because [adobe/appbuilder-quickstarts#15](https://github.com/adobe/appbuilder-quickstarts/pull/15) updates the example to properly document and use the `ts-loader` method.

## Test plan

- [ ] Verify the Example project section reads correctly without the caveat

Made with [Cursor](https://cursor.com)