### PR TITLE
Fix Node.js runtime version in TypeScript Actions example

### DIFF
--- a/src/pages/guides/app_builder_guides/configuration/typescript-actions.md
+++ b/src/pages/guides/app_builder_guides/configuration/typescript-actions.md
@@ -73,7 +73,7 @@ runtimeManifest:
         my-action:
           function: actions/my-action/index.ts
           web: 'yes'
-          runtime: nodejs:18
+          runtime: nodejs:22
 ```
 
 That's it. App Builder will use Webpack with `ts-loader` to compile your TypeScript action during build and deployment.


### PR DESCRIPTION
## Summary

- Update `runtime: nodejs:18` to `runtime: nodejs:22` in the TypeScript Actions example

Node.js 18 reached EOL on April 30, 2025. The example should use a supported LTS version.

## Test plan

- [x] Verify the example YAML snippet shows `nodejs:22`
