### PR TITLE
fix: resolve broken internal links flagged by lint

### DIFF
--- a/src/pages/get_started/app_builder_get_started/troubleshoot.md
+++ b/src/pages/get_started/app_builder_get_started/troubleshoot.md
@@ -18,7 +18,7 @@ This is a guide for troubleshooting some of the most common issues you may encou
 
 ## General debugging
 
-When your action code doesn't work as expected, you may want to check the logs to investigate what went wrong. App Builder provides the [Logging SDK](https://github.com/adobe/aio-lib-core-logging) for this; please check out [App Builder's Application Logging](../guides/application_logging/logging.md) for more details.
+When your action code doesn't work as expected, you may want to check the logs to investigate what went wrong. App Builder provides the [Logging SDK](https://github.com/adobe/aio-lib-core-logging) for this; please check out [App Builder's Application Logging](../../guides/app_builder_guides/application_logging/logging.md) for more details.
 
 To see the latest activations of your project, run this command:
 

--- a/src/pages/get_started/app_builder_get_started/troubleshoot.md
+++ b/src/pages/get_started/app_builder_get_started/troubleshoot.md
@@ -18,7 +18,7 @@ This is a guide for troubleshooting some of the most common issues you may encou
 
 ## General debugging
 
-When your action code doesn't work as expected, you may want to check the logs to investigate what went wrong. App Builder provides the [Logging SDK](https://github.com/adobe/aio-lib-core-logging) for this; please check out [App Builder's Application Logging](../guides/application_logging.md) for more details.
+When your action code doesn't work as expected, you may want to check the logs to investigate what went wrong. App Builder provides the [Logging SDK](https://github.com/adobe/aio-lib-core-logging) for this; please check out [App Builder's Application Logging](../guides/application_logging/logging.md) for more details.
 
 To see the latest activations of your project, run this command:
 

--- a/src/pages/guides/app_builder_guides/application_logging/logging.md
+++ b/src/pages/guides/app_builder_guides/application_logging/logging.md
@@ -183,4 +183,4 @@ It returns the most recent 10 log forwarding errors for the current log forwardi
 
 Return to [Guides Index](../../index.md).
 
-Return to [App Builder Overview](../../../intro_and_overview/app_builder_overview.md).
+Return to [App Builder Overview](../../../intro_and_overview/what-is-app-builder.md).

--- a/src/pages/guides/app_builder_guides/architecture_overview/architecture-overview.md
+++ b/src/pages/guides/app_builder_guides/architecture_overview/architecture-overview.md
@@ -143,6 +143,6 @@ App Builder uses webpack for bundling I/O Runtime action code. See [Webpack Conf
 
 Continue to [Storage](../storage/index.md).
 
-Return to [App Builder Overview](../../../intro_and_overview/app_builder_overview.md).
+Return to [App Builder Overview](../../../intro_and_overview/what-is-app-builder.md).
 
 Return to [Guides Index](../../index.md).

--- a/src/pages/guides/app_builder_guides/index.md
+++ b/src/pages/guides/app_builder_guides/index.md
@@ -27,7 +27,7 @@ Welcome to the App Builder Guides section. Here you'll find comprehensive docume
 * [Deployment](deployment/deployment.md)
 * [Content Delivery Network](cdn/index.md)
 * [Application Logging](application_logging/logging.md)
-* [Events](events/custom-events.md)
+* [Events](../../resources/event-driven/)
 * [Extensions](extensions/extensions.md)
 * [Security](security/index.md)
 

--- a/src/pages/guides/app_builder_guides/index.md
+++ b/src/pages/guides/app_builder_guides/index.md
@@ -27,7 +27,7 @@ Welcome to the App Builder Guides section. Here you'll find comprehensive docume
 * [Deployment](deployment/deployment.md)
 * [Content Delivery Network](cdn/index.md)
 * [Application Logging](application_logging/logging.md)
-* [Events](../../resources/event-driven/)
+* [Events](../../resources/event-driven/index.md)
 * [Extensions](extensions/extensions.md)
 * [Security](security/index.md)
 

--- a/src/pages/guides/app_builder_guides/storage/application-state.md
+++ b/src/pages/guides/app_builder_guides/storage/application-state.md
@@ -39,7 +39,7 @@ hello-world:
 
 ### Considerations about security
 
-For authentication with Adobe APIs, you should leverage [App Builder Security Guideline](security/index.md) using our supported SDKs.
+For authentication with Adobe APIs, you should leverage [App Builder Security Guideline](../security/) using our supported SDKs.
 
 For other 3rd party systems and APIs when provisioning actions with the secrets/passwords is a must, you can then use the default params as demonstrated above. In order to support this use case, all default params are automatically encrypted. They are decrypted just before the action code is executed. Thus, the only time you have access to the decrypted value is while executing the action code.
 

--- a/src/pages/guides/app_builder_guides/storage/application-state.md
+++ b/src/pages/guides/app_builder_guides/storage/application-state.md
@@ -39,7 +39,7 @@ hello-world:
 
 ### Considerations about security
 
-For authentication with Adobe APIs, you should leverage [App Builder Security Guideline](../security/) using our supported SDKs.
+For authentication with Adobe APIs, you should leverage [App Builder Security Guideline](../security/index.md) using our supported SDKs.
 
 For other 3rd party systems and APIs when provisioning actions with the secrets/passwords is a must, you can then use the default params as demonstrated above. In order to support this use case, all default params are automatically encrypted. They are decrypted just before the action code is executed. Thus, the only time you have access to the decrypted value is while executing the action code.
 

--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -19,7 +19,7 @@ For a close examination of App Builder's components, operation, and resources, f
 * [Deployment](app_builder_guides/deployment/deployment.md)
 * [Development](app_builder_guides/development.md)
 * [Distribution](app_builder_guides/distribution.md)
-* [Events](app_builder_guides/events/custom-events.md)
+* [Events](../resources/event-driven/)
 * [CDN](app_builder_guides/cdn/index.md)
 * [Extensions](app_builder_guides/extensions/extensions.md)
 * [Integration with Adobe Experience Cloud](app_builder_guides/exc_app/aec-integration.md)
@@ -48,4 +48,4 @@ These materials may be read as a tutorial or as a set of reference materials. St
 
 ## Next step
 
-Return to [App Builder Overview](../intro_and_overview/app_builder_overview.md).
+Return to [App Builder Overview](../intro_and_overview/what-is-app-builder.md).

--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -19,7 +19,7 @@ For a close examination of App Builder's components, operation, and resources, f
 * [Deployment](app_builder_guides/deployment/deployment.md)
 * [Development](app_builder_guides/development.md)
 * [Distribution](app_builder_guides/distribution.md)
-* [Events](../resources/event-driven/)
+* [Events](../resources/event-driven/index.md)
 * [CDN](app_builder_guides/cdn/index.md)
 * [Extensions](app_builder_guides/extensions/extensions.md)
 * [Integration with Adobe Experience Cloud](app_builder_guides/exc_app/aec-integration.md)

--- a/src/pages/guides/runtime_guides/creating-actions.md
+++ b/src/pages/guides/runtime_guides/creating-actions.md
@@ -315,10 +315,6 @@ Requirements to deploy a ZIP action are:
 
 - Create a manifest file
 
-### wskdeploy
-
-If you need to install `wskdeploy`, check [Setting up the wskdeploy CLI](tools/wskdeploy_install.md).
-
 ### Package.json file
 
 You use the package.json file to specify the dependencies. If you don't have one already, in the same folder where your function files are, run `npm init -y`.

--- a/src/pages/guides/runtime_guides/index.md
+++ b/src/pages/guides/runtime_guides/index.md
@@ -36,7 +36,6 @@ Welcome to the Runtime Guides section. Here you'll find comprehensive documentat
 ## Tools and Reference
 
 * [CLI Usage](tools/cli-install.md)
-* [WSKDeploy Install](tools/wskdeploy_install.md)
 * [Reference Documentation](reference_docs/index.md)
 
 ## Next step

--- a/src/pages/guides/runtime_guides/tools/index.md
+++ b/src/pages/guides/runtime_guides/tools/index.md
@@ -3,7 +3,6 @@
 The most important tools for working with Adobe I/O Runtime are:
 
 - [aio CLI](cli-install.md) to manage namespaces and authentication for the `aio` CLI
-- [wskdeploy CLI](wskdeploy_install.md) to deploy multiple actions and packages
 
 ## Next step
 

--- a/src/pages/resources/index.md
+++ b/src/pages/resources/index.md
@@ -121,4 +121,4 @@ Learn why is it a good idea to build event-driven applications and how to build 
 
 ## Next step
 
-Return to [App Builder Overview](../intro_and_overview/app_builder_overview.md).
+Return to [App Builder Overview](../intro_and_overview/what-is-app-builder.md).


### PR DESCRIPTION
## Summary

Fixes all `missing-file` lint errors that started failing after a lint tool update. All broken links are in pre-existing files — no content changes, navigation corrections only.

## Changes

| File | Fix |
|------|-----|
| `troubleshoot.md` | `application_logging.md` → `application_logging/logging.md` |
| `logging.md`, `architecture-overview.md`, `guides/index.md`, `resources/index.md` | `app_builder_overview.md` → `what-is-app-builder.md` (file was renamed) |
| `guides/app_builder_guides/index.md`, `guides/index.md` | `events/custom-events.md` → `../../resources/event-driven/` (page moved to resources) |
| `storage/application-state.md` | `security/index.md` → `../security/` (missing `../` in relative path) |
| `creating-actions.md`, `runtime_guides/index.md`, `tools/index.md` | Removed `wskdeploy_install.md` references (file removed, wskdeploy is deprecated) |

## Related

Discovered when I created PR #524 (release notes update) which is failing lint due to these pre-existing errors.