### PR TITLE
Add trial signup page

### DIFF
--- a/src/pages/trial/index.md
+++ b/src/pages/trial/index.md
@@ -1,0 +1,4 @@
+---
+title: App Builder Trial Sign up
+frameSrc: https://53444-appbuildertrialform.adobeio-static.net/index.html
+---


### PR DESCRIPTION
## Summary
- Adds an App Builder trial signup page at `/app-builder/docs/trial/`
- Embeds the production trial form via `frameSrc`

## Context
The primary trial page lives in `AdobeDocs/app-builder-trial` and is deployed at `/app-builder/trial/`, but that repo's deploy branch has a stale iframe URL. This page serves as a backup until that's resolved.