### PR TITLE
Add Admin Console instructions for product profile and user role assignment

### DIFF
--- a/src/pages/get_started/app_builder_get_started/set-up.md
+++ b/src/pages/get_started/app_builder_get_started/set-up.md
@@ -30,6 +30,46 @@ Here you'll learn what systems you need to access, how to access them, and how t
 
 **[A GitHub account](https://github.com/)** is optional but highly recommended for setting up your CI/CD workflow.
 
+### Granting App Builder access in Adobe Admin Console
+
+If you are an IMS organization administrator, follow these steps to grant App Builder access to your developers. Once you complete these steps, users can sign in to [Adobe Developer Console](https://developer.adobe.com/console) and start building.
+
+A user needs two things to access App Builder:
+
+1. Membership in a product profile under the App Builder product
+2. The **Developer** or **System Administrator** role in the IMS organization
+
+> **Note:** Adobe does not use product profiles to scope App Builder permissions — every profile under the App Builder product grants the same access. However, the [Adobe Admin Console](https://adminconsole.adobe.com/) requires at least one profile to be selected before you can save a user assignment, so you must create one before assigning users.
+
+#### 1. Create a product profile for App Builder
+
+If your App Builder product does not already have a product profile, create one:
+
+1. Sign in to the [Adobe Admin Console](https://adminconsole.adobe.com/) and switch to the IMS organization where App Builder is provisioned.
+2. Open the **Products** tab and select **App Builder** from the product list.
+3. Click **New Profile**.
+4. Enter a profile name (any name is fine — for example, `App Builder Users`) and an optional description, then click **Next** and **Save**.
+
+#### 2. Assign users the Developer or System Administrator role
+
+Adobe Developer Console only surfaces App Builder to users who hold the Developer or System Administrator role.
+
+To grant the **Developer** role:
+
+1. In the [Adobe Admin Console](https://adminconsole.adobe.com/), open the **Users** tab and select **Developers**.
+2. Click **Add Developer**.
+3. Enter the user's email address.
+4. Under **Select Products and User Groups**, choose **App Builder** and select the product profile you created above.
+5. Click **Save**.
+
+To grant the **System Administrator** role instead (full org-wide admin access):
+
+1. In the [Adobe Admin Console](https://adminconsole.adobe.com/), open the **Users** tab and select **Administrators**.
+2. Click **Add Admin**.
+3. Enter the user's email address, leave the admin role set to **System Administrator**, and click **Save**. System Administrators automatically have access to App Builder and do not need to be added to a product profile separately.
+
+For more details on roles and permissions in the Admin Console, see the [Adobe Admin Console documentation](https://helpx.adobe.com/enterprise/using/admin-roles.html).
+
 ## Local environment setup
 
 ### Required tools


### PR DESCRIPTION
## Summary

- Adds a new **Granting App Builder access in Adobe Admin Console** subsection to `set-up.md` covering the steps IMS org admins need to follow.
- Documents that an App Builder product profile must be created in Admin Console before users can be assigned (Admin Console requires a profile to save the assignment, even though Adobe does not actually scope App Builder permissions by profile).
- Explains how to assign users either the **Developer** role (scoped via the App Builder product profile) or the **System Administrator** role (org-wide).

## Why

Customers with App Builder entitlements are hitting two recurring snags that the docs don't cover today:

1. They open Admin Console, find the App Builder product, but cannot save a user assignment because no product profile exists.
2. They assign users to App Builder but those users still don't see App Builder in Developer Console because they lack the Developer or System Administrator role.

Both have come up multiple times in customer escalations. This PR closes that gap in the Set Up guide.

## Test plan

- [ ] Render `src/pages/get_started/app_builder_get_started/set-up.md` and verify the new section appears under "Access and credentials" with the correct heading hierarchy.
- [ ] Verify links resolve: `https://adminconsole.adobe.com/`, `https://developer.adobe.com/console`, and the Adobe Admin Console roles helpx page.