### PR TITLE
Fix linter warnings in set-up.md

### DIFF
--- a/src/pages/get_started/app_builder_get_started/set-up.md
+++ b/src/pages/get_started/app_builder_get_started/set-up.md
@@ -5,7 +5,7 @@ keywords:
   - Local Environment
   - Set up
 title: Set Up Access, Environment, and Tools
-description: App Builder is a complete framework that enables enterprise developers to build and deploy custom web applications that extend Adobe Experience Cloud solutions and run on Adobe infrastructure.
+description: Set up access, credentials, your local environment, and the tools you need to develop Adobe App Builder applications.
 ---
 
 # Set Up Access, Environment, and Tools
@@ -22,7 +22,7 @@ Here you'll learn what systems you need to access, how to access them, and how t
   
   - Customers should request access from their account manager or their company IT/Marketing admin
   
-  - Partners should request App Builder access from their partner manager, or Sandbox access though the [Adobe Solution Partner Portal](https://solutionpartners.adobe.com/home.html)
+  - Partners should request App Builder access from their partner manager, or Sandbox access though the [Adobe Solution Partner Portal](https://partners.adobe.com/digitalexperience/)
 
 **App Builder access** is only available with a purchased license. 
 
@@ -56,9 +56,9 @@ We aim to provide similar quality of local development experience on Windows 10 
 
 #### Supported terminals for the CLI
 
-The [CLI](https://github.com/adobe/aio-cli) uses the popular [inquirer](https://www.npmjs.com/package/inquirer) package for all its interactive functions such as application generators.
+The [CLI](https://github.com/adobe/aio-cli) uses the popular [inquirer](https://github.com/SBoudrias/Inquirer.js) package for all its interactive functions such as application generators.
 
-See [inquirer's Support section](https://www.npmjs.com/package/inquirer#support-os-terminals) and its [known issues](https://www.npmjs.com/package/inquirer#known-issues) for up-to-date details.
+See the [inquirer documentation](https://github.com/SBoudrias/Inquirer.js#readme) for up-to-date details on supported terminals and known issues.
 
 ### Optional tool
 


### PR DESCRIPTION
## Summary

Cleanup of five pre-existing linter warnings on `src/pages/get_started/app_builder_get_started/set-up.md` that were surfaced in the lint report on #566. None of them are fatal (the lint check currently passes), but they show up as noise on every PR that touches this directory.

- Shorten the frontmatter `description` from 192 chars to 117 chars to satisfy the `check-frontmatter` rule (under 160).
- Replace the redirecting `https://solutionpartners.adobe.com/home.html` link with its final destination `https://partners.adobe.com/digitalexperience/` to satisfy the `no-dead-urls` redirect rule.
- Replace three `https://www.npmjs.com/package/inquirer` links (one bare, two with `#support-os-terminals` / `#known-issues` anchors) with `https://github.com/SBoudrias/Inquirer.js`. The npm URLs are flagged as dead by the linter; the GitHub repo is the canonical home now and the anchors on the npm page no longer exist on the new monorepo README.

## Why not also fix the other warnings?

The lint report on #566 surfaces ~428 warnings repo-wide, but the vast majority are unrelated to set-up.md and would belong in separate, file-scoped cleanups. I kept this PR tight to `set-up.md` so it can be reviewed and landed quickly.

## Test plan

- [ ] Re-run the Lint workflow on this PR and confirm the five warnings listed above no longer appear under `src/pages/get_started/app_builder_get_started/set-up.md` in the posted linter report.
- [ ] Open the rendered `set-up.md` page and visually verify the Inquirer documentation link resolves correctly and the Solution Partner Portal link still lands on the right page.