### PR TITLE
Repo-wide lint cleanup: redirects, frontmatter, alt text, dead URLs

### DIFF
--- a/src/pages/get_started/app_builder_get_started/ai-development-tools.md
+++ b/src/pages/get_started/app_builder_get_started/ai-development-tools.md
@@ -165,7 +165,7 @@ AI assistants generate better code when they understand your project structure. 
 - Use current API versions (Workfront v21.0, AEM OpenAPI)
 
 ## Documentation
-- App Builder and Runtime: https://developer.adobe.com/app-builder/docs/
+- App Builder and Runtime: https://developer.adobe.com/app-builder/docs/intro_and_overview/
 ```
 
 **For Cursor**, point to the [App Builder skills folder](https://github.com/adobe/skills) as described in the setup section above.
@@ -188,7 +188,7 @@ All formats serve the same purpose: giving the AI assistant context about App Bu
 
 ## Resources
 
-- [App Builder Documentation](https://developer.adobe.com/app-builder/docs/)
+- [App Builder Documentation](https://developer.adobe.com/app-builder/docs/intro_and_overview/)
 - [App Builder Adobe Summit Session: Build Fast, Secure AI-Powered Integrations with Adobe App Builder - OS605](https://business.adobe.com/summit/2026/sessions/build-fast-secure-aipowered-integrations-with-adob-os605.html)
 - [AEM AI Coding Agents Guide](https://www.aem.live/developer/ai-coding-agents)
 - [MCP Server Generator](https://github.com/adobe/generator-app-remote-mcp-server-generic)

--- a/src/pages/get_started/app_builder_get_started/app-builder-intro.md
+++ b/src/pages/get_started/app_builder_get_started/app-builder-intro.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: How it Works
+description: 'Overview of how App Builder works and what you''ll learn in the get-started tutorial series.'
 ---
 
 # Get Started with App Builder

--- a/src/pages/get_started/app_builder_get_started/first-app.md
+++ b/src/pages/get_started/app_builder_get_started/first-app.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Creating your First App Builder Application
+description: 'Step-by-step guide to creating, configuring, and deploying your first App Builder application.'
 ---
 
 # Create your First App Builder Application

--- a/src/pages/get_started/app_builder_get_started/first-app.md
+++ b/src/pages/get_started/app_builder_get_started/first-app.md
@@ -18,7 +18,7 @@ Make sure you have [access to App Builder](set-up.md#access-and-credentials), an
 
 ## 2. Create a new project on Developer Console
 
-[Adobe Developer Console](https://developer.adobe.com/developer-console/) gives you access to [APIs](https://developer.adobe.com/developer-console/docs/guides//guides/apis-and-services#apis), [SDKs](https://github.com/adobe/aio-sdk) and Developer tools to integrate and extend Adobe products. In App Builder, you will need access to [Adobe I/O Runtime](../runtime_getting_started/setup.md) credentials to deploy your application, and access to API credentials if you want to access Adobe APIs in your application.
+[Adobe Developer Console](https://developer.adobe.com/developer-console/) gives you access to [APIs](https://developer.adobe.com/developer-console/docs/guides/apis-and-services#apis), [SDKs](https://github.com/adobe/aio-sdk) and Developer tools to integrate and extend Adobe products. In App Builder, you will need access to [Adobe I/O Runtime](../runtime_getting_started/setup.md) credentials to deploy your application, and access to API credentials if you want to access Adobe APIs in your application.
 
 Follow these instructions to set up your project:
 
@@ -63,7 +63,7 @@ Follow these instructions to set up your project:
 
      ![Project Preview](../../images/console-5.png)
 
-7. Create a new workspace or select a workspace to add [APIs](https://developer.adobe.com/developer-console/docs/guides//guides/services/#add-api) and [Events](https://developer.adobe.com/developer-console/docs/guides//guides/services/services-add-event) that you will need for your application.
+7. Create a new workspace or select a workspace to add [APIs](https://developer.adobe.com/developer-console/docs/guides/services/#add-api) and [Events](https://developer.adobe.com/developer-console/docs/guides/services/services-add-event) that you will need for your application.
 
     ![Workspace](../../images/console-6.png)
 
@@ -237,7 +237,7 @@ select type of actions to generate (Press <space> to select, <a> to toggle all, 
  ◉ Generic
 ```
 
-These sample actions will help you get started quickly and illustrate best practices for integrating with [Adobe APIs](https://developer.adobe.com/developer-console/docs/guides//guides/services/#add-api) using [SDK](https://github.com/adobe/aio-sdk) in your applications.
+These sample actions will help you get started quickly and illustrate best practices for integrating with [Adobe APIs](https://developer.adobe.com/developer-console/docs/guides/services/#add-api) using [SDK](https://github.com/adobe/aio-sdk) in your applications.
 You may not see all the options listed below on your command line, because they are recommendations based on the credentials you added in the selected workspace. As with the preceding step, you can select any number of them:
 
 - **Adobe Target**, including dependencies and examples of accessing the [Adobe Target API](https://developers.adobetarget.com/api/#admin-apis)

--- a/src/pages/get_started/app_builder_get_started/first-app.md
+++ b/src/pages/get_started/app_builder_get_started/first-app.md
@@ -17,7 +17,7 @@ Make sure you have [access to App Builder](set-up.md#access-and-credentials), an
 
 ## 2. Create a new project on Developer Console
 
-[Adobe Developer Console](https://developer.adobe.com/developer-console/) gives you access to [APIs](https://developer.adobe.com/developer-console/docs/guides/apis-and-services#apis), [SDKs](https://github.com/adobe/aio-sdk) and Developer tools to integrate and extend Adobe products. In App Builder, you will need access to [Adobe I/O Runtime](../runtime_getting_started/setup.md) credentials to deploy your application, and access to API credentials if you want to access Adobe APIs in your application.
+[Adobe Developer Console](https://developer.adobe.com/developer-console/) gives you access to [APIs](https://developer.adobe.com/developer-console/docs/guides//guides/apis-and-services#apis), [SDKs](https://github.com/adobe/aio-sdk) and Developer tools to integrate and extend Adobe products. In App Builder, you will need access to [Adobe I/O Runtime](../runtime_getting_started/setup.md) credentials to deploy your application, and access to API credentials if you want to access Adobe APIs in your application.
 
 Follow these instructions to set up your project:
 
@@ -62,11 +62,11 @@ Follow these instructions to set up your project:
 
      ![Project Preview](../../images/console-5.png)
 
-7. Create a new workspace or select a workspace to add [APIs](https://developer.adobe.com/developer-console/docs/guides/services/#add-api) and [Events](https://developer.adobe.com/developer-console/docs/guides/services/services-add-event) that you will need for your application.
+7. Create a new workspace or select a workspace to add [APIs](https://developer.adobe.com/developer-console/docs/guides//guides/services/#add-api) and [Events](https://developer.adobe.com/developer-console/docs/guides//guides/services/services-add-event) that you will need for your application.
 
     ![Workspace](../../images/console-6.png)
 
-To learn more about Adobe Developer Console, please refer to [Console Documentation](https://developer.adobe.com/developer-console/docs).
+To learn more about Adobe Developer Console, please refer to [Console Documentation](https://developer.adobe.com/developer-console/docs/guides/).
 
 ## 3. Sign in from the CLI
 
@@ -236,14 +236,14 @@ select type of actions to generate (Press <space> to select, <a> to toggle all, 
  ◉ Generic
 ```
 
-These sample actions will help you get started quickly and illustrate best practices for integrating with [Adobe APIs](https://developer.adobe.com/developer-console/docs/guides/services/#add-api) using [SDK](https://github.com/adobe/aio-sdk) in your applications.
+These sample actions will help you get started quickly and illustrate best practices for integrating with [Adobe APIs](https://developer.adobe.com/developer-console/docs/guides//guides/services/#add-api) using [SDK](https://github.com/adobe/aio-sdk) in your applications.
 You may not see all the options listed below on your command line, because they are recommendations based on the credentials you added in the selected workspace. As with the preceding step, you can select any number of them:
 
 - **Adobe Target**, including dependencies and examples of accessing the [Adobe Target API](https://developers.adobetarget.com/api/#admin-apis)
 - **Adobe Analytics**, including dependencies and examples of accessing the [Adobe Analytics 2.0 API](https://adobedocs.github.io/analytics-2.0-apis/)
-- **Adobe Audience Manager: Customer Data**, including dependencies and examples of accessing the [Adobe Audience Manager Customer Data API](https://docs.adobe.com/content/help/en/audience-manager/user-guide/api-and-sdk-code/api.html)
-- **Adobe Campaign Standard**, including dependencies and examples of accessing the [Adobe Campaign Standard (ACS) API](https://docs.adobe.com/content/help/en/campaign-standard/using/working-with-apis/get-started-apis.html)
-- **Adobe Experience Platform: Realtime Customer Profile**, including dependencies and examples of accessing the [Realtime Customer Profile API of Adobe Experience Platform](https://developer.adobe.com/experience-platform-apis/references/profile/)
+- **Adobe Audience Manager: Customer Data**, including dependencies and examples of accessing the [Adobe Audience Manager Customer Data API](https://experienceleague.adobe.com/en/docs/audience-manager/user-guide/api-and-sdk-code/api)
+- **Adobe Campaign Standard**, including dependencies and examples of accessing the [Adobe Campaign Standard (ACS) API](https://experienceleague.adobe.com/en/docs/campaign-standard/using/working-with-apis/get-started-apis)
+- **Adobe Experience Platform: Realtime Customer Profile**, including dependencies and examples of accessing the [Realtime Customer Profile API of Adobe Experience Platform](https://developer.adobe.com/experience-platform-apis/references/profile)
 - **Generic**, a generic back-end action with hello-world flow that can be reused and modified, for simple serverless computing, third-party API integration, and more
 
 If you included `Web Assets` under Adobe I/O App features above, you will be given the choice to include the React Spectrum-based UI template or a raw HTML/JS UI template:
@@ -256,7 +256,7 @@ If you included `Web Assets` under Adobe I/O App features above, you will be giv
 
 - The `React Spectrum 3 UI` template adds a React-based UI with [React Spectrum](https://react-spectrum.adobe.com/) components included
 
-- The `Raw HTML/JS UI` will add a raw HTML/JS/CSS UI with [Spectrum CSS](https://opensource.adobe.com/spectrum-css) styles included.
+- The `Raw HTML/JS UI` will add a raw HTML/JS/CSS UI with [Spectrum CSS](https://opensource.adobe.com/spectrum-css/) styles included.
   
   Both templates come with boilerplate code needed to integrate your App Builder application with [Adobe Experience Cloud](../../guides/app_builder_guides/exc_app/aec-integration.md)
 

--- a/src/pages/get_started/app_builder_get_started/index.md
+++ b/src/pages/get_started/app_builder_get_started/index.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: App Builder and Adobe I/O Runtime
+description: 'Introduction to App Builder and Adobe I/O Runtime for building cloud-native applications on Adobe infrastructure.'
 ---
 
 # App Builder and Adobe I/O Runtime

--- a/src/pages/get_started/app_builder_get_started/publish-app.md
+++ b/src/pages/get_started/app_builder_get_started/publish-app.md
@@ -75,7 +75,7 @@ Click on `App Builder Apps` to discover all the applications published for your 
 
 ![](../../images/approval-myapp-customapps.png)
 
-# Publishing your headless App Builder app
+## Publishing your headless App Builder app
 
 The `App Builder Apps` Adobe Experience Cloud lists only App Builder SPAs. If you publish a headless app, please refer to our Code Lab [Headless Apps with App Builder](../../resources/barcode-reader/index.md).
 

--- a/src/pages/get_started/app_builder_get_started/publish-app.md
+++ b/src/pages/get_started/app_builder_get_started/publish-app.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Publishing Your First App Builder Application
+description: 'How to submit, review, and publish App Builder SPAs through Developer Console, Adobe Exchange, and Adobe Experience Cloud.'
 ---
 
 # Publishing Your First App Builder Application

--- a/src/pages/get_started/app_builder_get_started/publish-app.md
+++ b/src/pages/get_started/app_builder_get_started/publish-app.md
@@ -29,51 +29,51 @@ The final app is based on the Production workspace, so it is important to make s
 
 To begin the approval process, navigate to the Production workspace and select **Submit for approval** in the top-right corner of the screen or **Approval** in the left navigation.
 
-![](../../images/approval-production-overview.png)
+![Approval screen in the Production workspace](../../images/approval-production-overview.png)
 
 On the Approval screen you will be able to fill out the **App Submission Details** form.
 
 These details will be visible to people who use your app and administrators who review your application. Once the form is completed, select **Submit** to begin the approval process.
 
-![](../../images/approval-app-submission-details.png)
+![App submission details form](../../images/approval-app-submission-details.png)
 
 You will be returned to the Approval screen, where the Status of your application should now be "In Review."
 
-![](../../images/approval-in-review.png)
+![Approval screen showing application status In Review](../../images/approval-in-review.png)
 
 Following a review by your organization administrators, your application will either be approved and published, or rejected. If it is rejected, your Admin will be able to include a note telling you what went wrong so you can fix the error and resubmit.
 
-![](../../images/approval-app-rejected.png)
+![Approval screen showing a rejected application](../../images/approval-app-rejected.png)
 
 ### Published app
 
 Once your application has been submitted for approval, the Admin can see it pending for review in Adobe Exchange. The next section will describe Admin approval flow from Adobe Exchange. From Console side, once an application has been approved, its Status will be updated to Published and the application will be available for use by employees within your enterprise organization.
 
-![](../../images/approval-published.png)
+![Approval screen showing a published application](../../images/approval-published.png)
 
 ## Administrator review of your app from Adobe Exchange
 
 After you submit an application for approval, your organization's administrators can find it in Adobe Exchange under Manage → App Builder applications → Private distribution. Your submitted application will appear with a Pending Review status.
 
-![](../../images/approval-myexchange.png)
+![Pending Review listing in Adobe Exchange private distribution](../../images/approval-myexchange.png)
 
 The reviewer can review this app and approve it or reject it. If the application is rejected, your admin will be able to include a note telling you what went wrong, so you can fix the error and resubmit.
 
-![](../../images/approval-myexchange-review.png)
+![Adobe Exchange app review screen for an administrator](../../images/approval-myexchange-review.png)
 
 After the application is approved, the reviewer can also unpublish the app, requiring the app owner to resubmit it for review and approval.
 
-![](../../images/approval-myexchange-revoke.png)
+![Adobe Exchange unpublish action for an approved application](../../images/approval-myexchange-revoke.png)
 
 ## Check your published app at Experience Cloud
 
 Once the reviewer has approved your application, you will be notified by email and your app will appear at Adobe Experience Cloud:
 
-![](../../images/approval-myapp-home.png)
+![Approved app on the Adobe Experience Cloud home page](../../images/approval-myapp-home.png)
 
 Click on `App Builder Apps` to discover all the applications published for your organization.
 
-![](../../images/approval-myapp-customapps.png)
+![App Builder Apps list in Adobe Experience Cloud](../../images/approval-myapp-customapps.png)
 
 ## Publishing your headless App Builder app
 

--- a/src/pages/get_started/app_builder_get_started/set-up.md
+++ b/src/pages/get_started/app_builder_get_started/set-up.md
@@ -22,7 +22,7 @@ Here you'll learn what systems you need to access, how to access them, and how t
   
   - Customers should request access from their account manager or their company IT/Marketing admin
   
-  - Partners should request App Builder access from their partner manager, or Sandbox access though the [Adobe Solution Partner Portal](https://solutionpartners.adobe.com/home.html)
+  - Partners should request App Builder access from their partner manager, or Sandbox access though the [Adobe Solution Partner Portal](https://partners.adobe.com/digitalexperience/)
 
 **App Builder access** is only available with a purchased license. 
 

--- a/src/pages/get_started/app_builder_get_started/set-up.md
+++ b/src/pages/get_started/app_builder_get_started/set-up.md
@@ -5,7 +5,7 @@ keywords:
   - Local Environment
   - Set up
 title: Set Up Access, Environment, and Tools
-description: App Builder is a complete framework that enables enterprise developers to build and deploy custom web applications that extend Adobe Experience Cloud solutions and run on Adobe infrastructure.
+description: Get the access, credentials, and local tooling you need to start building App Builder applications.
 ---
 
 # Set Up Access, Environment, and Tools

--- a/src/pages/get_started/app_builder_get_started/troubleshoot.md
+++ b/src/pages/get_started/app_builder_get_started/troubleshoot.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Troubleshooting Common Issues
+description: 'Troubleshooting guide for the most common issues encountered while developing App Builder applications.'
 ---
 
 # Troubleshooting Common Issues

--- a/src/pages/get_started/index.md
+++ b/src/pages/get_started/index.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - App Builder
+  - Getting Started
+  - Runtime
+title: 'Getting Started with App Builder'
+description: 'Choose between the App Builder and Runtime getting-started paths and explore the rest of the App Builder documentation.'
+---
+
 # Getting Started with App Builder
 
 Welcome to the Getting Started section of App Builder documentation. Here you'll find comprehensive guides to help you start working with App Builder and Adobe I/O Runtime.

--- a/src/pages/get_started/runtime_getting_started/activations.md
+++ b/src/pages/get_started/runtime_getting_started/activations.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Activations
+  - OpenWhisk
+title: 'Retrieve Action Invocation Results'
+description: 'Use aio rt:activation commands to list and retrieve invocation records, logs, and responses for Adobe I/O Runtime actions.'
+---
+
 # Retrieve Action Invocation Results
 
 The activation record of an action invocation contains information to help you understand what happened. It contains the invocation's: 

--- a/src/pages/get_started/runtime_getting_started/deploy.md
+++ b/src/pages/get_started/runtime_getting_started/deploy.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Actions
+  - Deploy
+title: 'Deploy Your First Adobe I/O Runtime Action'
+description: 'Create, deploy, and test your first Adobe I/O Runtime action using the aio CLI.'
+---
+
 # Deploy Your First Adobe I/O Runtime Action
 
 In this step, you will create an I/O Runtime action, test it, and deploy it. 

--- a/src/pages/get_started/runtime_getting_started/entities.md
+++ b/src/pages/get_started/runtime_getting_started/entities.md
@@ -1,3 +1,16 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Actions
+  - Namespaces
+  - Triggers
+  - Rules
+  - Packages
+title: 'Entities and Core Concepts'
+description: 'Glossary of Adobe I/O Runtime entities including actions, namespaces, triggers, rules, packages, sequences, and feeds.'
+---
+
 # Entities and Core Concepts
 
 Adobe I/O Runtime's computing model is composed of functional elements or entities, and the interactions among them. This glossary defines the most important entities, outlines their interactions, and links to relevant resources in the Guides and elsewhere in this documentation.

--- a/src/pages/get_started/runtime_getting_started/how-runtime-works.md
+++ b/src/pages/get_started/runtime_getting_started/how-runtime-works.md
@@ -1,8 +1,12 @@
-```yaml
+---
 keywords:
-  - [need keywords]
-title: How I/O Runtime works
-```
+  - Adobe I/O
+  - Runtime
+  - OpenWhisk
+  - Architecture
+title: 'How I/O Runtime works'
+description: 'How Adobe I/O Runtime uses the Apache OpenWhisk architecture to provide function-as-a-service execution.'
+---
 
 # How Adobe I/O Runtime Works
 

--- a/src/pages/get_started/runtime_getting_started/how-runtime-works.md
+++ b/src/pages/get_started/runtime_getting_started/how-runtime-works.md
@@ -60,7 +60,7 @@ Note the `$userNamespace` variable. Runtime requests require access to the same 
 
 #### Receiving: nginx
 
-[Nginx](https://www.nginx.com/) is a reverse proxy and HTTP server. The OpenWhisk architecture uses it to terminal SSL and forward the HTTP request to the next component in the processing loop.
+[Nginx](https://www.f5.com/products/nginx) is a reverse proxy and HTTP server. The OpenWhisk architecture uses it to terminal SSL and forward the HTTP request to the next component in the processing loop.
 
 #### Interpreting: the Controller
 

--- a/src/pages/get_started/runtime_getting_started/how-runtime-works.md
+++ b/src/pages/get_started/runtime_getting_started/how-runtime-works.md
@@ -12,7 +12,7 @@ description: 'How Adobe I/O Runtime uses the Apache OpenWhisk architecture to pr
 
 Adobe I/O Runtime is based on the open source Apache OpenWhisk platform, and uses the OpenWhisk architecture to provide function-as-a-service. Here is a high-level look at the architecture:
 
-![The OpenWhisk architecture](https://developer.adobe.com/runtime/docs/static/2f65d806954291bfd2a474f3c8b2f9f4/73c8b/howitworks_f01.png)
+![The OpenWhisk architecture](../../images/howitworks_f01.png)
 
 The figure shows how Runtime (via OpenWhisk) is set up to respond to events and direct invocations. Whether the event comes from an external or internal source, it is associated with a trigger, which invokes an action according to any rules that are applied. Actions can also be invoked directly through the Runtime (OpenWhisk) CLI or the REST API.
 

--- a/src/pages/get_started/runtime_getting_started/how-runtime-works.md
+++ b/src/pages/get_started/runtime_getting_started/how-runtime-works.md
@@ -54,7 +54,7 @@ Host: $openwhiskEndpoint
 
 Note the `$userNamespace` variable. Runtime requests require access to the same namespace in which the action was created. When users are configured for Runtime accounts, they are given their own personal namespaces. 
 
-![](../../images/howitworks_f02.png)
+![Diagram of the Runtime internal process flow](../../images/howitworks_f02.png)
 
 *Internal process flow*
 

--- a/src/pages/get_started/runtime_getting_started/index.md
+++ b/src/pages/get_started/runtime_getting_started/index.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Getting Started
+  - Serverless
+title: 'Get Started with Adobe I/O Runtime'
+description: 'Introduction to Adobe I/O Runtime, the serverless computing platform that powers App Builder applications.'
+---
+
 # Get Started with Adobe I/O Runtime
 
 Adobe I/O Runtime is Adobe’s serverless computing platform based on Apache OpenWhisk, an open-source project of the Apache Software Foundation. Runtime lets you deploy your own custom code to the cloud and call it as needed, so you can execute functions, also called "actions," from the cloud without deploying or configuring a server. 

--- a/src/pages/get_started/runtime_getting_started/resources.md
+++ b/src/pages/get_started/runtime_getting_started/resources.md
@@ -6,11 +6,11 @@ Adobe I/O Runtime is built on top of Apache OpenWhisk, so blogs, documentation, 
 
 ## Resources
 
-A good starting point is the [Apache OpenWhisk repository](https://github.com/apache/incubator-openwhisk/tree/master/docs).
+A good starting point is the [Apache OpenWhisk repository](https://github.com/apache/openwhisk/tree/master/docs).
 
 ## Social media
 
-You can follow our team on [Twitter](https://twitter.com/adobeio), [Medium](https://medium.com/adobetech/tagged/platform), and [Youtube](https://www.youtube.com/channel/UCDtYqOjS9Eq9gacLcbMwhhQ).
+You can follow our team on [Twitter](https://x.com/adobeio), [Medium](https://medium.com/adobetech/tagged/platform), and [Youtube](https://www.youtube.com/channel/UCDtYqOjS9Eq9gacLcbMwhhQ).
 
 ## Support
 

--- a/src/pages/get_started/runtime_getting_started/resources.md
+++ b/src/pages/get_started/runtime_getting_started/resources.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - OpenWhisk
+  - Resources
+  - Support
+title: 'Resources and support'
+description: 'Resources, social media accounts, and community support channels for Adobe I/O Runtime developers.'
+---
+
 <HeroSimple slots="heading, text" />
 
 # Resources and support

--- a/src/pages/get_started/runtime_getting_started/setup.md
+++ b/src/pages/get_started/runtime_getting_started/setup.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Setup
+  - CLI
+  - Namespace
+title: 'Set up Your Environment'
+description: 'Install the aio CLI, create a Developer Console namespace, and sign in to start using Adobe I/O Runtime.'
+---
+
 # Set up Your Environment
 
 ## Get access

--- a/src/pages/get_started/runtime_getting_started/understanding-runtime.md
+++ b/src/pages/get_started/runtime_getting_started/understanding-runtime.md
@@ -12,9 +12,9 @@ Actions may be invoked by HTTP calls (RESTful or HTTP) or by other actions. Acti
 
 Actions may be organized into any number of **packages** within a namespace. Packages are used to organize the code, manage different versions of the same action, or share code with other tenants or applications. Packages marked **shareable** may be bound to the namespaces of anyone who has their full name, in the manner of symbolic links.
 
-![](../../images/quickstart-programming-model.png)
+![Diagram of the Runtime programming model with actions, namespaces, and packages](../../images/quickstart-programming-model.png)
 
-![](../../images/quickstart-shared-packages.png)
+![Diagram showing how shareable packages bind to other namespaces](../../images/quickstart-shared-packages.png)
 
 Actions may be invoked anonymously - with no authorization required - or with authentication. Runtime supports basic authorization  Developers can implement their own auth. We will be adding support for IMS based auth.
 
@@ -24,7 +24,7 @@ Adobe I/O Runtime is built on the Apache OpenWhisk open-source project, so many 
 
 This diagram shows the high-level architecture of I/O Runtime built on OpenWhisk:
 
-![](../../images/quickstart-components.png)
+![High-level Runtime architecture diagram built on OpenWhisk](../../images/quickstart-components.png)
 
 This is the sequence by which Runtime components execute user code when an action is executed:
 

--- a/src/pages/get_started/runtime_getting_started/understanding-runtime.md
+++ b/src/pages/get_started/runtime_getting_started/understanding-runtime.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Programming Model
+  - OpenWhisk
+title: 'Understanding Adobe I/O Runtime'
+description: 'Programming model, components, and architecture of Adobe I/O Runtime, the serverless platform that powers App Builder.'
+---
+
 # Understanding Adobe I/O Runtime
 
 Serverless platforms greatly simplify the development and operation of business applications. Successful use of them takes advantage of their many strengths, while working around their limitations. This Quick Start Guide explores the most critical of these considerations as they apply to I/O Runtime.

--- a/src/pages/get_started/runtime_getting_started/understanding-runtime.md
+++ b/src/pages/get_started/runtime_getting_started/understanding-runtime.md
@@ -20,7 +20,7 @@ Actions may be invoked anonymously - with no authorization required - or with au
 
 ## Understanding I/O Runtime components
 
-Adobe I/O Runtime is built on the Apache OpenWhisk open-source project, so many resources written for Apache OpenWhisk also apply to Adobe I/O Runtime. The [Apache OpenWhisk repository](https://github.com/apache/incubator-openwhisk/tree/master/docs) is a useful resource.
+Adobe I/O Runtime is built on the Apache OpenWhisk open-source project, so many resources written for Apache OpenWhisk also apply to Adobe I/O Runtime. The [Apache OpenWhisk repository](https://github.com/apache/openwhisk/tree/master/docs) is a useful resource.
 
 This diagram shows the high-level architecture of I/O Runtime built on OpenWhisk:
 
@@ -144,7 +144,7 @@ This is just the beginning for Adobe I/O Runtime. We encourage you to help us en
 
 ### Social media
 
-You can follow the Adobe I/O team on [Twitter](https://twitter.com/adobeio), [Medium](https://medium.com/adobetech/tagged/platform), and [Youtube](https://www.youtube.com/channel/UCDtYqOjS9Eq9gacLcbMwhhQ).
+You can follow the Adobe I/O team on [Twitter](https://x.com/adobeio), [Medium](https://medium.com/adobetech/tagged/platform), and [Youtube](https://www.youtube.com/channel/UCDtYqOjS9Eq9gacLcbMwhhQ).
 
 ### Support
 

--- a/src/pages/guides/app_builder_guides/application-state.md
+++ b/src/pages/guides/app_builder_guides/application-state.md
@@ -5,6 +5,7 @@ keywords:
 - API Documentation
 - Developer Tooling
 title: Storage Options
+description: 'Compare Database, Files, and State storage services available out-of-the-box for persisting App Builder application data.'
 ---
 
 

--- a/src/pages/guides/app_builder_guides/application_logging/azure-log-analytics.md
+++ b/src/pages/guides/app_builder_guides/application_logging/azure-log-analytics.md
@@ -10,6 +10,7 @@ keywords:
   - Azure
   - Azure Log Analytics
 title: Forwarding Logs to Azure Log Analytics
+description: 'Configure an App Builder application to forward logs to an Azure Log Analytics workspace.'
 ---
 
 # Forwarding Logs to Azure Log Analytics

--- a/src/pages/guides/app_builder_guides/application_logging/azure-log-analytics.md
+++ b/src/pages/guides/app_builder_guides/application_logging/azure-log-analytics.md
@@ -18,7 +18,7 @@ This guide covers configuration of your App Builder application to forward logs 
 
 ## Prerequisites
 
-1. Access to an Azure Log Analytics workspace. If you need to create one, follow [Azure's guide](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/quick-create-workspace)
+1. Access to an Azure Log Analytics workspace. If you need to create one, follow [Azure's guide](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/quick-create-workspace)
 2. Local development setup for your App Builder application
 3. The latest version of AIO CLI. Check by running `aio --version`; update by running `npm install -g @adobe/aio-cli`
 
@@ -61,7 +61,7 @@ This guide covers configuration of your App Builder application to forward logs 
    
    ## Next steps
    
-   If you are unable to set up log forwarding using these procedures, please visit Adobe [App Builder forums](https://experienceleaguecommunities.adobe.com/t5/app-builder/ct-p/app-builder) for support.
+   If you are unable to set up log forwarding using these procedures, please visit Adobe [App Builder forums](https://experienceleaguecommunities.adobe.com/) for support.
    
    Return to [Managing Application Logs](logging.md).
    

--- a/src/pages/guides/app_builder_guides/application_logging/new-relic.md
+++ b/src/pages/guides/app_builder_guides/application_logging/new-relic.md
@@ -9,6 +9,7 @@ keywords:
   - Monitoring
   - New Relic
 title: Forwarding Logs to New Relic
+description: 'Configure an App Builder application to forward logs to a New Relic deployment using an Ingest license API key.'
 ---
 
 # Forwarding Logs to New Relic

--- a/src/pages/guides/app_builder_guides/application_logging/splunk-cloud.md
+++ b/src/pages/guides/app_builder_guides/application_logging/splunk-cloud.md
@@ -10,6 +10,7 @@ keywords:
   - Splunk
   - Splunk Cloud
 title: Forwarding Logs to Splunk Cloud
+description: 'Configure an App Builder application to forward logs to a Splunk Cloud index using the HTTP event collector.'
 ---
 
 # Forwarding Logs to Splunk Cloud

--- a/src/pages/guides/app_builder_guides/application_logging/splunk-enterprise.md
+++ b/src/pages/guides/app_builder_guides/application_logging/splunk-enterprise.md
@@ -10,6 +10,7 @@ keywords:
   - Splunk
   - Splunk Enterprise
 title: Forwarding Logs to Splunk Enterprise
+description: 'Configure an App Builder application to forward logs to a Splunk Enterprise index using the HTTP event collector.'
 ---
 
 # Forwarding Logs to Splunk Enterprise

--- a/src/pages/guides/app_builder_guides/architecture_overview/app-hooks.md
+++ b/src/pages/guides/app_builder_guides/architecture_overview/app-hooks.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: App Builder application tooling lifecycle event hooks
+description: 'Reference for lifecycle event hooks you can define in app.config.yaml to run before, after, or in place of aio app commands.'
 ---
 
 # App Builder Application Tooling Lifecycle Event Hooks

--- a/src/pages/guides/app_builder_guides/architecture_overview/architecture-overview.md
+++ b/src/pages/guides/app_builder_guides/architecture_overview/architecture-overview.md
@@ -20,7 +20,7 @@ These applications may be headless or headful, as described below.
 
 Headless applications consist of a set of serverless actions or sequences deployed to [I/O Runtime](../../../intro_and_overview/what-is-app-builder.md#what-is-adobe-io-runtime), Adobe's serverless platform.
 
-Headless applications integrate well with remote scripts or processes that invoke them, for example [AEM Assets workflows](https://docs.adobe.com/content/help/en/experience-manager-65/assets/using/assets-workflow.html) or [ACS activities](https://docs.adobe.com/content/help/en/campaign-standard/using/managing-processes-and-data/data-management-activities/external-api.html).
+Headless applications integrate well with remote scripts or processes that invoke them, for example [AEM Assets workflows](https://experienceleague.adobe.com/en/docs/experience-manager-65/content/assets/using/assets-workflow) or [ACS activities](https://experienceleague.adobe.com/en/docs/campaign-standard/using/managing-processes-and-data/data-management-activities/external-api).
 
 ### Headful applications
 
@@ -73,14 +73,14 @@ The [main SDK library](https://github.com/adobe/aio-sdk) bundles smaller, reusab
 
 - The [Adobe Analytics](https://github.com/adobe/aio-lib-analytics) SDK library provides a client for the [Adobe Analytics 2.0 API](https://adobedocs.github.io/analytics-2.0-apis/)
 - The [Adobe Target](https://github.com/adobe/aio-lib-target) SDK library provides a client for the [Adobe Target 1.0 API](https://Developers.adobetarget.com/api/)
-- The [Adobe Campaign Standard](https://github.com/adobe/aio-lib-campaign-standard) SDK library provides a client for the [Adobe Campaign Standard API](https://experienceleague.adobe.com/docs/campaign-standard/using/working-with-apis/get-started-apis.html?lang=en)
+- The [Adobe Campaign Standard](https://github.com/adobe/aio-lib-campaign-standard) SDK library provides a client for the [Adobe Campaign Standard API](https://experienceleague.adobe.com/en/docs/campaign-standard/using/working-with-apis/get-started-apis)
 
 ##### Integration with Adobe's Identity Management System (IMS)
 
-The [Adobe IMS SDK library](https://github.com/adobe/aio-lib-core-ims) adds authentication management capabilities to Adobe's Identity Management Services, for these scenarios:
+The [Adobe IMS SDK library](https://github.com/adobe/aio-lib-ims) adds authentication management capabilities to Adobe's Identity Management Services, for these scenarios:
 
-- [User-based (OAuth 2.0)](https://github.com/adobe/aio-lib-core-ims-oauth)
-- [Technical account-based (JWT Bearer-token)](https://github.com/adobe/aio-lib-core-ims-jwt)
+- [User-based (OAuth 2.0)](https://github.com/adobe/aio-lib-ims-oauth)
+- [Technical account-based (JWT Bearer-token)](https://github.com/adobe/aio-lib-ims-jwt)
 
 ##### Integration with additional services provided with App Builder
 
@@ -128,8 +128,8 @@ It lets Developers perform these actions on behalf of their App Builder applicat
 [CI/CD support](../deployment/cicd-for-app-builder-apps.md) provided with App Builder for App Builder applications includes:
 
 - [GitHub Actions](https://github.com/features/actions) to [setup the CLI](https://github.com/adobe/aio-cli-setup-action) and use it to [perform actions](https://github.com/adobe/aio-apps-action) such as application testing, build, and deployment
-- [GitHub Workflows](https://docs.github.com/en/actions/writing-workflows) to orchestrate the GitHub Actions upon specific events triggered against the application repository
-- [GitHub Secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) to store application secrets required for the execution of the GitHub Workflows against specific environments
+- [GitHub Workflows](https://docs.github.com/en/actions/how-tos/write-workflows) to orchestrate the GitHub Actions upon specific events triggered against the application repository
+- [GitHub Secrets](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets) to store application secrets required for the execution of the GitHub Workflows against specific environments
 
 ### Webpack
 

--- a/src/pages/guides/app_builder_guides/architecture_overview/architecture-overview.md
+++ b/src/pages/guides/app_builder_guides/architecture_overview/architecture-overview.md
@@ -6,7 +6,7 @@ keywords:
   - SDK Library
   - Migration Guides
 title: Architecture Overview
-description: An App Builder Application is a serverless application that extends Adobe Product APIs. These applications can be headless or headful. Each of these types is described in more detail in the sections that follow.
+description: Overview of headless and headful App Builder application architectures and the SDK components they use to extend Adobe product APIs.
 ---
 
 # Architecture Overview

--- a/src/pages/guides/app_builder_guides/architecture_overview/introduction-to-react-spectrum.md
+++ b/src/pages/guides/app_builder_guides/architecture_overview/introduction-to-react-spectrum.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Introduction to React Spectrum
+description: 'Introduction to the React Spectrum component library that implements Adobe''s Spectrum design language.'
 ---
 
 # Introduction to React Spectrum

--- a/src/pages/guides/app_builder_guides/architecture_overview/using-sdks.md
+++ b/src/pages/guides/app_builder_guides/architecture_overview/using-sdks.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Using Client SDKs for Accessing Adobe APIs
+description: 'Use Adobe client SDKs to call Experience Cloud APIs such as Analytics, Audience Manager, Campaign Standard, and Target.'
 ---
 
 # Using Client SDKs for Accessing Adobe APIs

--- a/src/pages/guides/app_builder_guides/configuration/configuration.md
+++ b/src/pages/guides/app_builder_guides/configuration/configuration.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - App Builder
+  - Configuration
+  - app.config.yaml
+title: 'App Builder Configuration Files'
+description: 'Reference for the app.config.yaml, .env, and .aio configuration files that define an App Builder application.'
+---
+
 # App Builder Configuration Files
 
 ## Overview

--- a/src/pages/guides/app_builder_guides/configuration/sequences.md
+++ b/src/pages/guides/app_builder_guides/configuration/sequences.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - App Builder
+  - Sequences
+  - OpenWhisk
+  - Configuration
+title: 'Configuring Sequences in app.config.yaml'
+description: 'Configure App Builder action sequences declaratively in app.config.yaml using the OpenWhisk wskdeploy specification.'
+---
+
 # Configuring Sequences in app.config.yaml
 
 ## Overview

--- a/src/pages/guides/app_builder_guides/configuration/sequences.md
+++ b/src/pages/guides/app_builder_guides/configuration/sequences.md
@@ -31,7 +31,7 @@ Sequences are ideal when you need to:
 **When NOT to use sequences:**
 - When you need conditional logic or branching
 - When actions need to run in parallel
-- When you need error handling between steps (use a [conductor action](https://github.com/apache/incubator-openwhisk-composer/blob/master/docs/COMBINATORS.md) instead)
+- When you need error handling between steps (use a [conductor action](https://github.com/apache/openwhisk-composer/blob/master/docs/COMBINATORS.md) instead)
 - When latency is critical (sequences add cumulative latency as each action waits for the previous one to complete)
 
 ## Basic Syntax

--- a/src/pages/guides/app_builder_guides/configuration/webpack-configuration.md
+++ b/src/pages/guides/app_builder_guides/configuration/webpack-configuration.md
@@ -13,7 +13,7 @@ keywords:
 
 ## Overview
 
-App Builder bundles Runtime action code using Webpack. Users can specify Webpack configurations for individual actions, sets of actions, or entire projects. See [the Webpack site](https://webpack.js.org/configuration) for configuration options.
+App Builder bundles Runtime action code using Webpack. Users can specify Webpack configurations for individual actions, sets of actions, or entire projects. See [the Webpack site](https://webpack.js.org/configuration/) for configuration options.
 
 ## Configuration file
 

--- a/src/pages/guides/app_builder_guides/deployment/cicd-for-app-builder-apps.md
+++ b/src/pages/guides/app_builder_guides/deployment/cicd-for-app-builder-apps.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: CI/CD for App Builder Applications
+description: 'Overview of continuous integration and continuous delivery options for App Builder applications.'
 ---
 
 # CI/CD for App Builder Applications: Overview

--- a/src/pages/guides/app_builder_guides/deployment/cicd-using-github-actions.md
+++ b/src/pages/guides/app_builder_guides/deployment/cicd-using-github-actions.md
@@ -70,7 +70,7 @@ Note: This guide refers to the "root of your App Builder app". The root of your 
 
 ## Step 4: Add secrets to your GitHub repository
 
-Before you can deploy your app from the CI/CD pipeline using GitHub Actions, you must add your application secrets to your repository. App Builder uses [GitHub Actions environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) to scope secrets per deployment target. To set up the `stage` environment:
+Before you can deploy your app from the CI/CD pipeline using GitHub Actions, you must add your application secrets to your repository. App Builder uses [GitHub Actions environments](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments) to scope secrets per deployment target. To set up the `stage` environment:
 
 1. Open your GitHub repository
 2. Navigate to the `Settings` tab > `Environments` on the left nav

--- a/src/pages/guides/app_builder_guides/development.md
+++ b/src/pages/guides/app_builder_guides/development.md
@@ -4,6 +4,7 @@ keywords:
   - Extensibility
   - API Documentation
   - Developer Tooling
+description: 'Run, develop, and debug App Builder applications locally using the aio CLI development server and hot reloading.'
 ---
 
 # Local Development

--- a/src/pages/guides/app_builder_guides/development.md
+++ b/src/pages/guides/app_builder_guides/development.md
@@ -4,6 +4,7 @@ keywords:
   - Extensibility
   - API Documentation
   - Developer Tooling
+title: Local Development
 description: 'Run, develop, and debug App Builder applications locally using the aio CLI development server and hot reloading.'
 ---
 

--- a/src/pages/guides/app_builder_guides/distribution.md
+++ b/src/pages/guides/app_builder_guides/distribution.md
@@ -6,7 +6,7 @@ keywords:
   - Public
   - Private
 title: Distribution
-description: The Developer Console and aio CLI provide features for developers to distribute their App Builder applications. This documentation focuses on the distribution step of this lifecycle.
+description: How to distribute App Builder applications publicly or privately using the Developer Console and the aio CLI.
 ---
 
 # Distribution Overview

--- a/src/pages/guides/app_builder_guides/distribution.md
+++ b/src/pages/guides/app_builder_guides/distribution.md
@@ -223,7 +223,7 @@ configSchema:
 
 ### Required products
 
-Developers of publicly distributable App Builder apps can define Adobe products that are required for their apps to work properly. The [Discover](https://developer.adobe.com/developer-distribution/experience-cloud/docs/guides/discoverandmanage/#discover) and [Acquire](https://developer.adobe.com/developer-distribution/experience-cloud/docs/guides/discoverandmanage/#acquire) sections of the distribution documentation show how these options are surfaced to customers.
+Developers of publicly distributable App Builder apps can define Adobe products that are required for their apps to work properly. The [distribution documentation](https://developer.adobe.com/developer-distribution/experience-cloud/docs/guides/) shows how these options are surfaced to customers when they discover and acquire your app.
 
 #### Defining required products
 

--- a/src/pages/guides/app_builder_guides/exc_app/aec-integration.md
+++ b/src/pages/guides/app_builder_guides/exc_app/aec-integration.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Integration Guide with Adobe Experience Cloud
+description: 'Integrate custom App Builder applications with the Adobe Experience Cloud unified shell using the @adobe/exc-app package.'
 ---
 
 # Integration with Adobe Experience Cloud

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/index.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/index.md
@@ -1,5 +1,6 @@
 ---
 title: 'Adobe Experience Cloud App Builder: Interfaces Index'
+description: 'Index of interfaces available in the Adobe Experience Cloud App Builder extensibility APIs.'
 ---
 
 # Interfaces Index

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/page-objectwithhref.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/page-objectwithhref.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: ObjectWithHref'
+description: 'Reference for the ObjectWithHref interface that represents a solution page by its URL.'
 ---
 
 # Interface: ObjectWithHref

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/page-objectwithpath.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/page-objectwithpath.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: ObjectWithPath'
+description: 'Reference for the ObjectWithPath interface that represents a solution page by its relative path.'
 ---
 
 # Interface: ObjectWithPath

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/page-pageapi.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/page-pageapi.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: PageApi'
+description: 'Reference for the PageApi interface that defines page-level APIs available to Experience Cloud solutions.'
 ---
 
 # Interface: PageAPI

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/page-pageapiproperties.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/page-pageapiproperties.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: PageAPIProperties'
+description: 'Reference for the PageApiProperties interface defining settable page-level attributes such as title and favicon.'
 ---
 
 # Interface: PageAPIProperties

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/runtime.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/runtime.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: Runtime'
+description: 'Reference for the Runtime interface that provides unified-shell APIs and event handling for solution authors.'
 ---
 
 # Interface: Runtime

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-callback.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-callback.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: Callback'
+description: 'Reference for the Callback function signature used by Experience Cloud top bar event handlers.'
 ---
 
 # Interface: Callback

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-customfeedbackconfig.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-customfeedbackconfig.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: CustomFeedbackConfig'
+description: 'Reference for the CustomFeedbackConfig interface that configures a custom feedback button in the Experience Cloud top bar.'
 ---
 
 # Interface: CustomFeedbackConfig

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-customsearchconfig.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-customsearchconfig.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: CustomSearchConfig'
+description: 'Reference for the CustomSearchConfig interface that configures a custom search button in the Experience Cloud top bar.'
 ---
 
 # Interface: CustomSearchConfig

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-externalfeedbackconfig.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-externalfeedbackconfig.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: ExternalFeedbackConfig'
+description: 'Reference for the ExternalFeedbackConfig interface that configures an external feedback button in the Experience Cloud top bar.'
 ---
 
 # Interface: ExternalFeedbackConfig

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-helpcenterfeedbackconfig.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-helpcenterfeedbackconfig.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: HelpCenterFeedbackConfig'
+description: 'Reference for the HelpCenterFeedbackConfig interface that configures a help center feedback button in the Experience Cloud top bar.'
 ---
 
 # Interface: HelpCenterFeedbackConfig

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-solution.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-solution.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: Solution'
+description: 'Reference for the Solution interface that defines icon, title, and shortTitle attributes for the top bar solution area.'
 ---
 
 # Interface: Solution

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-topbarapi.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-topbarapi.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: TopbarAPI'
+description: 'Reference for the TopbarAPI interface that defines APIs for customizing the Experience Cloud top bar.'
 ---
 
 # Interface: TopbarAPI

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-topbarapiproperties.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/topbar-topbarapiproperties.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: TopbarAPIProperties'
+description: 'Reference for the TopbarAPIProperties interface that lists settable attributes for the Experience Cloud top bar.'
 ---
 
 # Interface: TopbarAPIProperties

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/user-userapi.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/user-userapi.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: UserAPI'
+description: 'Reference for the UserAPI interface that exposes user information, authentication, and IMS events to solutions.'
 ---
 
 # Interface: UserAPI

--- a/src/pages/guides/app_builder_guides/exc_app/interfaces/user-userinfo.md
+++ b/src/pages/guides/app_builder_guides/exc_app/interfaces/user-userinfo.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Interface: UserInfo'
+description: 'Reference for the UserInfo interface describing user identity, IMS organization, and locale information.'
 ---
 
 # Interface: UserInfo

--- a/src/pages/guides/app_builder_guides/exc_app/migrate-app-to-exp-cloud-spa.md
+++ b/src/pages/guides/app_builder_guides/exc_app/migrate-app-to-exp-cloud-spa.md
@@ -1,5 +1,5 @@
 ---
-title: 'Migration tutorial - Standalone Application to DX Experience Cloud SPA v1'
+title: 'Migrate Standalone App to DX Experience Cloud SPA v1'
 ---
 
 # Migrating Apps to DX Experience Cloud v1 SPAs

--- a/src/pages/guides/app_builder_guides/exc_app/migrate-app-to-exp-cloud-spa.md
+++ b/src/pages/guides/app_builder_guides/exc_app/migrate-app-to-exp-cloud-spa.md
@@ -1,5 +1,6 @@
 ---
 title: 'Migrate Standalone App to DX Experience Cloud SPA v1'
+description: 'Migrate a standalone App Builder application to a DX Experience Cloud v1 Single-Page Application.'
 ---
 
 # Migrating Apps to DX Experience Cloud v1 SPAs

--- a/src/pages/guides/app_builder_guides/exc_app/modules/page.md
+++ b/src/pages/guides/app_builder_guides/exc_app/modules/page.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'External module: page'
+description: 'Reference for the Experience Cloud page module that lets solutions interact with and personalize the main page.'
 ---
 
 # External Module: Page

--- a/src/pages/guides/app_builder_guides/exc_app/modules/topbar.md
+++ b/src/pages/guides/app_builder_guides/exc_app/modules/topbar.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'External module: topbar'
+description: 'Reference for the Experience Cloud topbar module used to configure the solution area, workspaces, and custom search.'
 ---
 
 # External Module: Topbar

--- a/src/pages/guides/app_builder_guides/exc_app/modules/user.md
+++ b/src/pages/guides/app_builder_guides/exc_app/modules/user.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'External module: user'
+description: 'Reference for the Experience Cloud user module that exposes IMS organization, profile, and access token information.'
 ---
 
 # External Module: User

--- a/src/pages/guides/app_builder_guides/extensions/extension-migration-guide.md
+++ b/src/pages/guides/app_builder_guides/extensions/extension-migration-guide.md
@@ -34,7 +34,7 @@ Under the old file structure, initialization of a new App Builder Project in the
 5. `manifest.yml`: file describing back-end actions to deploy or redeploy
    - `manifest` file contents should adhere to the [OpenWhisk deployment YAML specification](https://github.com/apache/openwhisk-wskdeploy/tree/master/specification#package-specification). Once defined, the [CLI](https://github.com/adobe/aio-cli) uses this file to deploy or redeploy actions. You might see values like `$CUSTOMER_PROFILE_TENANT` listed on this page; they are environment variables that can be defined in the `.env` file.
 6. `package.json`: this file describes project definition and various metadata relevant to the project.
-    - It is used by `npm install` to install all the project's dependencies. The package is private and not expected to be published/shared on [npmjs.com](https://www.npmjs.com/). Learn more [here](https://docs.npmjs.com/about-packages-and-modules).
+    - It is used by `npm install` to install all the project's dependencies. The package is private and not expected to be published/shared on [npmjs.com](https://www.npmjs.com/). Learn more [here](https://docs.npmjs.com/about-packages-and-modules/).
 7. `.aio`: file containing configuration variables used by the [CLI](https://github.com/adobe/aio-cli) to facilitate the application, for example supported API services. This file can be committed to a source-code versioning system.
    - You may manually update the file, or use `aio config` commands to add or to configurations. Learn more about the [Config Plugin](https://github.com/adobe/aio-cli-plugin-config).
 8. `.env`: file containing environment variables useful for application development, for example Adobe I/O Runtime credentials and Adobe Product API tenant specifics  such as API key and secrets.
@@ -55,7 +55,7 @@ When extensions were introduced, the file structure changed to:
 2. `app.config.yaml`,  the master configuration file. It follows the same principle as the individual `ext.config.yaml`, and compiles these individual files into one comprehensive configuration upon application build.
 3. `lib`: a folder containing all the shared utility actions across different extension points.
 4. `package.json`: this file describes project definition and various metadata relevant to the project.
-    - It is used by `npm install` to install all the project's dependencies. The package is private and not expected to be published/shared on [npmjs.com](https://www.npmjs.com/). Learn more [here](https://docs.npmjs.com/about-packages-and-modules).
+    - It is used by `npm install` to install all the project's dependencies. The package is private and not expected to be published/shared on [npmjs.com](https://www.npmjs.com/). Learn more [here](https://docs.npmjs.com/about-packages-and-modules/).
 5. `.aio`: this file contains config variables that are useful for the [CLI](https://github.com/adobe/aio-cli) to facilitate the app, e.g. supported API services.
    - You can manually update the file or use the `aio config` commands to add or to remove configurations. Learn more about the [Config Plugin](https://github.com/adobe/aio-cli-plugin-config).
 6. `.env`: file containing environment variables useful for application development, for example Adobe I/O Runtime credentials and Adobe Product API tenant specifics such as API key and secrets.

--- a/src/pages/guides/app_builder_guides/extensions/extension-migration-guide.md
+++ b/src/pages/guides/app_builder_guides/extensions/extension-migration-guide.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Extension Migration Guide
+description: 'Migrate legacy App Builder applications created before July 2021 to the current file structure and configuration protocol.'
 ---
 
 # Migrating Legacy Applications

--- a/src/pages/guides/app_builder_guides/extensions/extensions.md
+++ b/src/pages/guides/app_builder_guides/extensions/extensions.md
@@ -9,7 +9,7 @@ title: Introduction to Extensions
 
 # Introduction to Extensions
 
-App Builder originally supported only Single-Page Applications (SPAs) accessed in [Experience Cloud UI](https://experience.adobe.com) and standalone Headless Applications. In response to customer requests, we added services like [AEM Asset Microservices](https://experienceleague.adobe.com/docs/experience-manager-cloud-service/assets/manage/asset-microservices-configure-and-use.html?lang=en) to extend Adobe products through App Builder.  But Developers still had to set up connections manually between AEM and their custom processing profiles. 
+App Builder originally supported only Single-Page Applications (SPAs) accessed in [Experience Cloud UI](https://experience.adobe.com) and standalone Headless Applications. In response to customer requests, we added services like [AEM Asset Microservices](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/assets/manage/asset-microservices-configure-and-use) to extend Adobe products through App Builder.  But Developers still had to set up connections manually between AEM and their custom processing profiles. 
 
 Extensions provide a simpler, more integrated way for Developers to extend products across the Adobe ecosystem. 
 

--- a/src/pages/guides/app_builder_guides/extensions/extensions.md
+++ b/src/pages/guides/app_builder_guides/extensions/extensions.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Introduction to Extensions
+description: 'Introduction to extension points and endpoints that let App Builder applications extend Adobe products.'
 ---
 
 # Introduction to Extensions

--- a/src/pages/guides/app_builder_guides/optimization.md
+++ b/src/pages/guides/app_builder_guides/optimization.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Optimizing App Builder Apps
+description: 'Techniques to optimize App Builder applications for security, performance, and operational cost.'
 ---
 
 # Optimizing App Builder Apps

--- a/src/pages/guides/app_builder_guides/optimization.md
+++ b/src/pages/guides/app_builder_guides/optimization.md
@@ -33,7 +33,7 @@ When you test this functionality for web action using Postman or a web browser w
 
 ## Returning large response payloads
 
-An Adobe I/O Runtime action can return a [response payload of 1MB](../runtime_guides/system-settings.md) - enough for most use cases. If your action will return a larger payload, we provide a scalable solution with [App Builder Files SDK](https://github.com/adobe/aio-lib-files). It allows you to [persist a binary file to the blob storage](https://github.com/adobe/aio-lib-files/blob/master/doc/api.md#Files+write), obtain [a temporary downloadable URL](https://github.com/adobe/aio-lib-files/blob/master/doc/api.md#Files+generatePresignURL) and return an [HTTP Redirect response](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302) to the file with this URL. Here is a demonstration:
+An Adobe I/O Runtime action can return a [response payload of 1MB](../runtime_guides/system-settings.md) - enough for most use cases. If your action will return a larger payload, we provide a scalable solution with [App Builder Files SDK](https://github.com/adobe/aio-lib-files). It allows you to [persist a binary file to the blob storage](https://github.com/adobe/aio-lib-files/blob/master/doc/api.md#Files+write), obtain [a temporary downloadable URL](https://github.com/adobe/aio-lib-files/blob/master/doc/api.md#Files+generatePresignURL) and return an [HTTP Redirect response](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/302) to the file with this URL. Here is a demonstration:
 
 ```javascript
 const fileLocation = '/private-dir/large-image.png'

--- a/src/pages/guides/app_builder_guides/security/understanding-authentication.md
+++ b/src/pages/guides/app_builder_guides/security/understanding-authentication.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Understanding Authentication
+description: 'Overview of Adobe authentication options, OAuth 2.0 and JWT, and libraries to use them in App Builder applications.'
 ---
 
 # Understanding Authentication

--- a/src/pages/guides/app_builder_guides/storage/application-state.md
+++ b/src/pages/guides/app_builder_guides/storage/application-state.md
@@ -5,6 +5,7 @@ keywords:
 - API Documentation
 - Developer Tooling
 title: Dealing with Application State
+description: 'Manage application state using default parameters, environment variables, and the State and Files storage SDKs.'
 ---
 
 # Dealing with Application State

--- a/src/pages/guides/app_builder_guides/storage/db-commands.md
+++ b/src/pages/guides/app_builder_guides/storage/db-commands.md
@@ -14,7 +14,7 @@ description: Discover the essential commands and operations available in App Bui
 
 The database plugin in the AIO CLI is a utility that facilitates provisioning, initializing, querying, and monitoring workspace databases.
 
-The following is only a brief introduction to the DB Plugin. For more thorough documentation, see [aio-cli-plugin-app-storage](https://github.com/adobe/aio-cli-plugin-app-storage/tree/epic/abdb-implementation).
+The following is only a brief introduction to the DB Plugin. For more thorough documentation, see [aio-cli-plugin-app-storage](https://github.com/adobe/aio-cli-plugin-app-storage).
 
 ## Installation
 

--- a/src/pages/guides/app_builder_guides/storage/index.md
+++ b/src/pages/guides/app_builder_guides/storage/index.md
@@ -5,6 +5,7 @@ keywords:
 - API Documentation
 - Developer Tooling
 title: Storage Options
+description: 'Compare Database, Files, and State storage services available to App Builder applications.'
 ---
 
 # Storage Options

--- a/src/pages/guides/app_builder_guides/telemetry.md
+++ b/src/pages/guides/app_builder_guides/telemetry.md
@@ -5,7 +5,7 @@ keywords:
   - Developer Tooling
   - telemetry
 title: Telemetry
-description: The latest release of the Adobe Developer Platform CLI (v9.0.0) collects anonymous telemetry data about general usage.  This is an optional feature, and you may opt-out if you would not like to share your anonymous usage information.
+description: Optional anonymous usage telemetry collected by the Adobe Developer Platform CLI v9.0.0 and how to opt out.
 ---
 
 # Telemetry

--- a/src/pages/guides/contribution-guide.md
+++ b/src/pages/guides/contribution-guide.md
@@ -12,17 +12,17 @@ Thanks for choosing to contribute! The following are a set of guidelines to foll
 
 ## Code Of Conduct
 
-This project adheres to the Adobe [Code of Conduct](https://github.com/AdobeDocs/project-firefly/blob/main/.github/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [Adobe](mailto:Grp-opensourceoffice@adobe.com).
+This project adheres to the Adobe [Code of Conduct](https://github.com/AdobeDocs/app-builder/blob/main/.github/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [Adobe](mailto:Grp-opensourceoffice@adobe.com).
 
 ## Contributor License Agreement
 
-All third-party contributions to this project must be accompanied by a signed contributor license agreement. This gives Adobe permission to redistribute your contributions as part of the project. [Sign our CLA](http://opensource.adobe.com/cla.html). You only need to submit an Adobe CLA one time, so if you have submitted one previously, you are good to go!
+All third-party contributions to this project must be accompanied by a signed contributor license agreement. This gives Adobe permission to redistribute your contributions as part of the project. [Sign our CLA](https://opensource.adobe.com/cla.html). You only need to submit an Adobe CLA one time, so if you have submitted one previously, you are good to go!
 
 ## Code Reviews
 
 All submissions should come in the form of pull requests and need to be reviewed by project committers. Read [GitHub's pull request documentation](https://help.github.com/articles/about-pull-requests/) for more information on sending pull requests.
 
-Finally, please follow the [pull request template](https://github.com/AdobeDocs/project-firefly/blob/main/.github/PULL_REQUEST_TEMPLATE.md) when submitting a pull request.
+Finally, please follow the [pull request template](https://github.com/AdobeDocs/app-builder/blob/main/.github/PULL_REQUEST_TEMPLATE.md) when submitting a pull request.
 
 ## CLI and plugins best practices
 

--- a/src/pages/guides/index.md
+++ b/src/pages/guides/index.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Reference Documentation
+description: 'Index of App Builder guides covering architecture, configuration, deployment, security, and reference documentation.'
 ---
 
 # Guides Index

--- a/src/pages/guides/references.md
+++ b/src/pages/guides/references.md
@@ -12,7 +12,7 @@ title: Reference Documentation
 * [Adobe Developer Console](https://developer.adobe.com/developer-console/docs/guides/)
 * [Adobe CLI](https://github.com/adobe/aio-cli)
 * [App Builder Application Generators](https://github.com/adobe/generator-aio-app)
-* [Developer Console Project Generators](https://github.com/adobe/generator-aio-console)
+* [Developer Console Project Generators](https://github.com/adobe/aio-cli-lib-console)
 * [Adobe Authentication Library](https://github.com/adobe/aio-lib-ims)
 * [Token-Vending Machine](https://github.com/adobe/aio-tvm)
 * [SDK Libraries](https://github.com/adobe/aio-sdk)

--- a/src/pages/guides/references.md
+++ b/src/pages/guides/references.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Reference Documentation
+description: 'Reference links to the Adobe Developer Console, aio CLI, App Builder generators, and SDK libraries.'
 ---
 
 # Reference Documentation

--- a/src/pages/guides/runtime_guides/asynchronous-calls.md
+++ b/src/pages/guides/runtime_guides/asynchronous-calls.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Asynchronous
+  - Web Actions
+title: 'Asynchronous Calls'
+description: 'Patterns for running Adobe I/O Runtime work that exceeds the 60-second synchronous limit using asynchronous actions.'
+---
+
 # Asynchronous Calls
 
 The system executes web actions or REST APIs as synchronous (blocking) calls and gives them 60 seconds to complete their work. Actions that need more time can use asynchronous (async) calls, and use up to 180 minutes. 

--- a/src/pages/guides/runtime_guides/ci-cd-pipeline.md
+++ b/src/pages/guides/runtime_guides/ci-cd-pipeline.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - CI/CD
+  - Namespaces
+  - Versioning
+title: 'CI/CD Pipeline'
+description: 'Tools and patterns for building a CI/CD pipeline for Adobe I/O Runtime actions, including namespaces and package versioning.'
+---
+
 # CI/CD Pipeline
 
 Adobe I/O Runtime offers a number of tools to help you build a CI/CD pipeline for managing your actions. 

--- a/src/pages/guides/runtime_guides/creating-rest-apis.md
+++ b/src/pages/guides/runtime_guides/creating-rest-apis.md
@@ -319,7 +319,7 @@ Requests that originate from the IP addresses on the disallow list will be rejec
 
 > Note: be sure the `my-require-gw-validation-web-action` is configured as a web action with `-a require-gw-validation true`, or the action can be accessed publicly with no restrictions on the non-API URL. 
 
-# How long does it take to create or update an API?
+## How long does it take to create or update an API?
 
 It can take up to five minutes to see the changes from creation or update of an API.
 

--- a/src/pages/guides/runtime_guides/creating-rest-apis.md
+++ b/src/pages/guides/runtime_guides/creating-rest-apis.md
@@ -79,7 +79,7 @@ This will work provided that the actions are already created in that namespace.
 
 ## Enable CORS on an HTTP resource
 
-[CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) headers can be controlled either statically or dynamically.
+[CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS) headers can be controlled either statically or dynamically.
 
 ### Static CORS response with OpenAPI
 

--- a/src/pages/guides/runtime_guides/creating-rest-apis.md
+++ b/src/pages/guides/runtime_guides/creating-rest-apis.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - REST APIs
+  - Web Actions
+  - Swagger
+title: 'Creating REST APIs'
+description: 'Create REST APIs from Adobe I/O Runtime web actions using the aio CLI or Swagger definition files.'
+---
+
 # Creating REST APIs
 
 > Note: IO Runtime cleans up custom APIs that have not been accessed for 90 days.

--- a/src/pages/guides/runtime_guides/debugging.md
+++ b/src/pages/guides/runtime_guides/debugging.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Debugging
+  - Node.js
+title: 'Debugging Node.js Actions'
+description: 'Pointer to the updated debugging documentation for Adobe I/O Runtime Node.js actions in the App Builder guides.'
+---
+
 # Debugging Node.js Actions
 
 Visit the [updated documentation](https://developer.adobe.com/app-builder/docs/guides/app_builder_guides/development#debugging) to learn how to debug Node.js Actions.

--- a/src/pages/guides/runtime_guides/logging-monitoring.md
+++ b/src/pages/guides/runtime_guides/logging-monitoring.md
@@ -22,7 +22,7 @@ aio rt:activation:logs <activation ID>
 2018-11-14T22:23:00.002Z       stdout: 1542234180001: param = John Doe
 ```
 
-# Retrieving activations for blocking successful calls
+## Retrieving activations for blocking successful calls
 
 At scale, when you run millions of activations in a day, it may be difficult to extract the activations that failed in order to debug them. To help with this task, the system skips persisting the activation that succeeded. 
 

--- a/src/pages/guides/runtime_guides/logging-monitoring.md
+++ b/src/pages/guides/runtime_guides/logging-monitoring.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Logging
+  - Monitoring
+  - Activations
+title: 'Logging and Monitoring'
+description: 'Use the aio CLI to retrieve activations and logs for Adobe I/O Runtime actions while debugging or monitoring.'
+---
+
 # Logging and Monitoring
 
 The `AIO` CLI offers a number of tools you can use to debug your actions while running them on Adobe I/O Runtime.

--- a/src/pages/guides/runtime_guides/logging-monitoring.md
+++ b/src/pages/guides/runtime_guides/logging-monitoring.md
@@ -67,7 +67,7 @@ Although there is no out-of-the-box integration, there are still ways you can pu
 
 #### Epsagon
 
-One tool that made it easy to do this is [Epsagon](https://epsagon.com). Epsagon built an integration for OpenWhisk-based systems like I/O Runtime that simplifies seeing your activations, errors, latency information and logs. Check this [guide](https://docs.epsagon.com/docs/openwhisk?utm_source=adobe.io&utm_medium=referral&utm_campaign=adobe_io_docs) or this [video presentation](https://www.youtube.com/watch?v=4iprbivqrxQ&t=1517s) if you want to find more.
+One tool that made it easy to do this was Epsagon, which built an integration for OpenWhisk-based systems like I/O Runtime that simplified seeing your activations, errors, latency information, and logs. Watch the [video presentation](https://www.youtube.com/watch?v=4iprbivqrxQ&t=1517s) for an overview. (Note: Epsagon was acquired and its docs site is no longer available; comparable observability tools may offer similar OpenWhisk integrations.)
 
 #### New Relic
 

--- a/src/pages/guides/runtime_guides/reference_docs/api-ref.md
+++ b/src/pages/guides/runtime_guides/reference_docs/api-ref.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - API Reference
+  - Namespaces
+title: 'Adobe I/O Runtime API Reference'
+description: 'Reference for the Adobe I/O Runtime management API endpoints used to interact with namespaces programmatically.'
+---
+
 # Adobe I/O Runtime API Reference
 
 ## API endpoints

--- a/src/pages/guides/runtime_guides/reference_docs/cli-use.md
+++ b/src/pages/guides/runtime_guides/reference_docs/cli-use.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - aio CLI
+  - Commands
+title: 'Using aio CLI'
+description: 'Reference for the aio runtime command, its options, aliases, and subcommands for managing Runtime resources.'
+---
+
 # Using aio CLI
 
 ```

--- a/src/pages/guides/runtime_guides/reference_docs/configuringproxy.md
+++ b/src/pages/guides/runtime_guides/reference_docs/configuringproxy.md
@@ -1,3 +1,15 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Proxy
+  - nginx
+  - mTLS
+  - Security
+title: 'Configuring a Secure Proxy'
+description: 'Configure an nginx proxy with mutual TLS so Adobe I/O Runtime actions can reach backend services protected by IP allow lists.'
+---
+
 ## Configuring a Secure Proxy
 
 For security reasons, Runtime does not expose egress IPs. Customers who need a way to secure communication with downstream services using IP whitelisting can use a proxy between their backend service and I/O Runtime.

--- a/src/pages/guides/runtime_guides/reference_docs/configuringproxy.md
+++ b/src/pages/guides/runtime_guides/reference_docs/configuringproxy.md
@@ -4,7 +4,7 @@ For security reasons, Runtime does not expose egress IPs. Customers who need a w
 
 This can be done by adding a proxy component (in this example, an AWS EC2 instance running nginx). The proxy component will have a fixed IP address, so using an IP allowlist can secure the backend service. Communication between I/O Runtime and the proxy component will be secured via mutual TLS (mTLS) communication. 
 
-![](../../../images/configure-proxy.png)
+![Diagram of an nginx proxy fronting Runtime with mTLS to the backend](../../../images/configure-proxy.png)
 
 The following steps outline how to:
 

--- a/src/pages/guides/runtime_guides/reference_docs/environment-variables.md
+++ b/src/pages/guides/runtime_guides/reference_docs/environment-variables.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Environment Variables
+  - OpenWhisk
+title: 'Environment Variables'
+description: 'Reference for the OpenWhisk environment variables available to Adobe I/O Runtime actions at execution time.'
+---
+
 # Environment Variables
 
 When an action is being executed, your code can use the following environment variables:

--- a/src/pages/guides/runtime_guides/reference_docs/feeds.md
+++ b/src/pages/guides/runtime_guides/reference_docs/feeds.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Feeds
+  - Triggers
+  - Rules
+title: 'Using Feeds'
+description: 'How feed actions create and manage event streams that fire triggers in Adobe I/O Runtime.'
+---
+
 # Using Feeds
 
 Feeds are streams of events. The difference between [triggers](triggersrules.md 'Using Triggers and Rules') and feeds is:

--- a/src/pages/guides/runtime_guides/reference_docs/index.md
+++ b/src/pages/guides/runtime_guides/reference_docs/index.md
@@ -1,3 +1,12 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Reference Documentation
+title: 'Adobe I/O Runtime Reference Documentation'
+description: 'Index of reference documentation for Adobe I/O Runtime APIs, command-line tools, and entities.'
+---
+
 # Adobe I/O Runtime Reference Documentation
 
 This Guide contains reference documentation for Runtime APIs, command-line tools, and entities.

--- a/src/pages/guides/runtime_guides/reference_docs/multiple-regions.md
+++ b/src/pages/guides/runtime_guides/reference_docs/multiple-regions.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Regions
+  - AWS
+  - Routing
+title: 'Multiple Regions'
+description: 'How Adobe I/O Runtime deploys and routes actions across multiple AWS regions using latency-based routing.'
+---
+
 # Multiple Regions
 
 Actions are executed in one of four regions on AWS:

--- a/src/pages/guides/runtime_guides/reference_docs/packages.md
+++ b/src/pages/guides/runtime_guides/reference_docs/packages.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Packages
+  - OpenWhisk
+title: 'Working with Packages'
+description: 'Create, share, and bind Adobe I/O Runtime packages to organize actions and share default parameters.'
+---
+
 # Working with Packages
 
 Packages are a simple and yet important concept in I/O Runtime. You can use packages to handle versioning (deploy new version of your actions in a new package), create different actions with the same name within the same namespace, group together actions that are related, share actions with other parties, and much more.

--- a/src/pages/guides/runtime_guides/reference_docs/prepackages.md
+++ b/src/pages/guides/runtime_guides/reference_docs/prepackages.md
@@ -82,7 +82,7 @@ aio rt:trigger:create my-cron-trigger \
   --param stopDate "2028-01-01T00:00:00.000Z"
 ```
 
-Here are some examples of how to set various `cron` values - for more information, check this [page](http://crontab.org):
+Here are some examples of how to set various `cron` values - for more information, see [crontab.guru](https://crontab.guru/):
 
 - `* * * * *`: The Trigger fires at the top of every minute
 - `0 * * * *`: The Trigger fires at the top of every hour

--- a/src/pages/guides/runtime_guides/reference_docs/prepackages.md
+++ b/src/pages/guides/runtime_guides/reference_docs/prepackages.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Packages
+  - Alarms
+title: 'Pre-Installed Packages'
+description: 'Use the pre-installed alarms and other shared packages available to every Adobe I/O Runtime namespace.'
+---
+
 # Pre-Installed Packages
 
 These packages are pre-installed and available to any I/O Runtime user:

--- a/src/pages/guides/runtime_guides/reference_docs/runtimes.md
+++ b/src/pages/guides/runtime_guides/reference_docs/runtimes.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Node.js
+  - Runtimes
+title: 'Runtimes'
+description: 'Supported Node.js runtimes for Adobe I/O Runtime actions and the npm modules pre-installed in each.'
+---
+
 # Runtimes
 
 Adobe I/O Runtime supports the three latest Node.js versions (see the [Node.js release schedule](https://nodejs.org/en/about/previous-releases#release-schedule) for details). We encourage you to keep actions updated to the latest version so you can take advantage of latest security updates and the pre-warmed container feature that dramatically improves cold-start times.

--- a/src/pages/guides/runtime_guides/reference_docs/sequences-compositions.md
+++ b/src/pages/guides/runtime_guides/reference_docs/sequences-compositions.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Sequences
+  - Compositions
+  - OpenWhisk
+title: 'Sequences and Compositions'
+description: 'Orchestrate Adobe I/O Runtime actions using sequences for linear chains or compositions for branching control flow.'
+---
+
 # Sequences and Compositions
 
 There are two ways to orchestrate a series of action calls into a flow: sequences and compositions.

--- a/src/pages/guides/runtime_guides/reference_docs/sequences-compositions.md
+++ b/src/pages/guides/runtime_guides/reference_docs/sequences-compositions.md
@@ -29,7 +29,7 @@ If we apply this limitation to the example above, then `actionA` and `actionB` h
 
 If one of your actions needs more than 60 seconds (therefore putting the sequence over the limit), the only solution is to invoke it as a non-blocking action using the OpenWhisk npm module. So, using the same example, you could have `actionA` calling another action in a non-blocking manner. You can see an example of how to do this [here](../asynchronous-calls.md).
 
-Read more about sequences on the [OpenWhisk documentation page](https://github.com/apache/incubator-openwhisk/blob/master/docs/actions.md#creating-action-sequences).
+Read more about sequences on the [OpenWhisk documentation page](https://github.com/apache/openwhisk/blob/master/docs/actions.md).
 
 ## Compositions
 
@@ -73,8 +73,8 @@ This creates a composition called `compositionA`. Invoke it like any other actio
 
 More information is available at:
 
-* Apache OpenWhisk Composer [home page]( https://github.com/apache/incubator-openwhisk-composer)
-* [Combinators](https://github.com/apache/incubator-openwhisk-composer/blob/master/docs/COMBINATORS.md), with a complete list of the control-flow structure.
+* Apache OpenWhisk Composer [home page]( https://github.com/apache/openwhisk-composer)
+* [Combinators](https://github.com/apache/openwhisk-composer/blob/master/docs/COMBINATORS.md), with a complete list of the control-flow structure.
 
 ### Parallel compositions
 

--- a/src/pages/guides/runtime_guides/reference_docs/triggersrules.md
+++ b/src/pages/guides/runtime_guides/reference_docs/triggersrules.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Triggers
+  - Rules
+  - Events
+title: 'Using Triggers and Rules'
+description: 'Use triggers and rules in Adobe I/O Runtime to invoke actions in response to events.'
+---
+
 # Using Triggers and Rules
 
 Actions invoked directly in the CLI have limited application; Adobe I/O Runtime is most useful when it is configured to respond to events. Runtime features that support this are triggers and rules:

--- a/src/pages/guides/runtime_guides/reference_docs/wsk-use.md
+++ b/src/pages/guides/runtime_guides/reference_docs/wsk-use.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - wsk
+  - CLI
+  - OpenWhisk
+title: 'Using the wsk CLI'
+description: 'Reference for the legacy wsk CLI commands for interacting with Adobe I/O Runtime actions, triggers, and packages.'
+---
+
 # Using the wsk CLI
 
 You can use the `--help` flag to navigate the list of supported commands:

--- a/src/pages/guides/runtime_guides/securing-web-actions.md
+++ b/src/pages/guides/runtime_guides/securing-web-actions.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Web Actions
+  - Security
+  - Basic Authentication
+title: 'Securing Web Actions'
+description: 'Restrict access to Adobe I/O Runtime web actions using Basic Authentication, namespace credentials, or custom auth layers.'
+---
+
 # Securing Web Actions
 
 By default, a web action can be invoked by anyone knowing the action's URL. If you want to restrict 'access, either use Basic Authentication or you build your own authentication layer.

--- a/src/pages/guides/runtime_guides/securing-web-actions.md
+++ b/src/pages/guides/runtime_guides/securing-web-actions.md
@@ -51,7 +51,7 @@ aio rt:action:update my-require-validation-web-action main.js --web true -a requ
 
 To interact with the action, set up a security configuration in your Swagger API route for that action. Detailed instructions on how to do this can be found in [Securing API Endpoints](creating-rest-apis.md#securing-api-endpoints).  
 
-# Non-web actions
+## Non-web actions
 
 If your action is not a web action, you can still use your namespace credentials, base64 encoded, to call any of the actions in your namespace, like this:
 

--- a/src/pages/guides/runtime_guides/security-general.md
+++ b/src/pages/guides/runtime_guides/security-general.md
@@ -10,11 +10,11 @@ Every action is run in its own container. Containers may be reused for the same 
 
 Anything that runs on the internet and accepts user input is potentially vulnerable to cross-site scripting (XSS) attacks. These take a variety of forms and can be easily introduced if you are not careful.
 
-Parameters sent to actions are not sanitized by the Runtime system. These inputs should therefore be treated as unsafe and sanitized before they are used. For example, do not pass parameters directly to a SQL queries or evaluate them in JavaScript. A good resource on how to avoid XSS attacks is the [Open Web Application Security Project (OWASP) XSS documentation](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)).
+Parameters sent to actions are not sanitized by the Runtime system. These inputs should therefore be treated as unsafe and sanitized before they are used. For example, do not pass parameters directly to a SQL queries or evaluate them in JavaScript. A good resource on how to avoid XSS attacks is the [Open Web Application Security Project (OWASP) XSS documentation](https://owasp.org/www-community/attacks/xss/).
 
 ## Cookies
 
-You can set cookies in two ways in Runtime: from JavaScript on the page using [document.cookie](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie) calls, or by passing a [Header object from a web action](https://github.com/apache/incubator-openwhisk/blob/master/docs/webactions.md#web-actions) with a Set-Cookie header directive. The way Runtime hosts functions raises some particular concerns for Developers.
+You can set cookies in two ways in Runtime: from JavaScript on the page using [document.cookie](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie) calls, or by passing a [Header object from a web action](https://github.com/apache/openwhisk/blob/master/docs/webactions.md) with a Set-Cookie header directive. The way Runtime hosts functions raises some particular concerns for Developers.
 
 We discourage the use of cookies directly from web actions on Runtime: please see [Securing Web Actions](securing-web-actions.md) for details.
 

--- a/src/pages/guides/runtime_guides/security-general.md
+++ b/src/pages/guides/runtime_guides/security-general.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Security
+  - Sandboxing
+  - XSS
+title: 'Security Guide'
+description: 'Security considerations and best practices for Adobe I/O Runtime functions, covering sandboxing, XSS, cookies, and secrets.'
+---
+
 # Security Guide
 
 This guide reviews security issues to consider when working with Runtime functions. Only a subset of these may apply to your use case: for example, the section about cookies isn't relevant if you aren't using web actions. This guide will help you keep your functions secure and steer you away from practices that are risky in a serverless environment.

--- a/src/pages/guides/runtime_guides/system-settings.md
+++ b/src/pages/guides/runtime_guides/system-settings.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Limits
+  - System Settings
+title: 'System Settings'
+description: 'Reference table of Adobe I/O Runtime system settings and limits to consider when designing and debugging actions.'
+---
+
 # System Settings
 
 These are the system settings and limitations to consider when designing and debugging your actions.

--- a/src/pages/guides/runtime_guides/throughput-tuning.md
+++ b/src/pages/guides/runtime_guides/throughput-tuning.md
@@ -61,7 +61,7 @@ Encoded responses can't be cached, so the `Content-Encoding` response header mus
 
 ### Vary header
 
-The caching layer supports the use of [Vary header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Vary) to cache based on header fields as well as on URL and query parameters.
+The caching layer supports the use of [Vary header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Vary) to cache based on header fields as well as on URL and query parameters.
 
 This action responds to certain header fields while doing a complex calculation:
 

--- a/src/pages/guides/runtime_guides/throughput-tuning.md
+++ b/src/pages/guides/runtime_guides/throughput-tuning.md
@@ -1,3 +1,14 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Throughput
+  - Concurrency
+  - Performance
+title: 'Throughput Tuning'
+description: 'Tune Adobe I/O Runtime action concurrency and container reuse to maximize throughput and minimize cold-start latency.'
+---
+
 # Throughput Tuning
 
 ## Containers

--- a/src/pages/guides/runtime_guides/tools/cli-install.md
+++ b/src/pages/guides/runtime_guides/tools/cli-install.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - aio CLI
+  - Install
+title: 'Setting up the aio CLI'
+description: 'Install and update the aio CLI for managing Adobe I/O Runtime namespaces and authentication.'
+---
+
 # Setting up the aio CLI
 
 The `aio` CLI helps you to manage the `.wskprops` file as you use different namespaces. You will need `npm` to install it, so before you start, make sure you have the latest version of Node and npm installed.

--- a/src/pages/guides/runtime_guides/tools/index.md
+++ b/src/pages/guides/runtime_guides/tools/index.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Tools
+  - aio CLI
+title: 'Runtime Tools'
+description: 'Index of the tools available for working with Adobe I/O Runtime, including the aio CLI.'
+---
+
 # Runtime Tools
 
 The most important tools for working with Adobe I/O Runtime are:

--- a/src/pages/guides/runtime_guides/troubleshooting.md
+++ b/src/pages/guides/runtime_guides/troubleshooting.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Troubleshooting
+  - Local Storage
+title: 'Troubleshooting'
+description: 'Troubleshooting tips for Adobe I/O Runtime actions, including the local-storage-evicted error and mitigation strategies.'
+---
+
 # Troubleshooting
 
 If you're having trouble with your actions or activations, here is a common issue and its solution.

--- a/src/pages/guides/runtime_guides/using-packages.md
+++ b/src/pages/guides/runtime_guides/using-packages.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Packages
+  - Feeds
+title: 'Using Packages with Adobe I/O Runtime'
+description: 'Bundle related Adobe I/O Runtime actions into packages, share parameters, and create feed actions.'
+---
+
 # Using Packages with Adobe I/O Runtime
 
 Individual actions (functions) can be effective, but you may also need to create sets of actions that interact with each other, or make them available to other Developers. Runtime meets these requirements with packages.

--- a/src/pages/guides/runtime_guides/using-runtime.md
+++ b/src/pages/guides/runtime_guides/using-runtime.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - Runtime
+  - Actions
+  - Packages
+title: 'Using Adobe I/O Runtime'
+description: 'Roadmap for using Adobe I/O Runtime to deploy actions, build packages, secure web actions, and tune throughput.'
+---
+
 # Using Adobe I/O Runtime
 
 Adobe I/O Runtime is more than a way of deploying individual actions and invoking them directly in the CLI. With Runtime, you can deploy groups of related actions as packages, share them with others, set up actions as webhooks to automate responses to events, and access Runtime actions through the API. The following pages guide you through the process:

--- a/src/pages/intro_and_overview/business-case.md
+++ b/src/pages/intro_and_overview/business-case.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Business case
+description: 'Why enterprises choose App Builder over third-party or do-it-yourself customizations to extend Adobe solutions.'
 ---
 
 # Business case for App Builder

--- a/src/pages/intro_and_overview/business-case.md
+++ b/src/pages/intro_and_overview/business-case.md
@@ -48,8 +48,8 @@ Execution of App Builder apps on Adobe's I/O Runtime serverless platform adds ev
 
 ## Examples from the real world
 
-- **Cognizant** demonstration airline website: [Building a Real-Time Airline Application Using Adobe Experience Platform, Adobe I/O Runtime and App Builder](https://www.netcentric.biz/insights/2020/06/building-an-aep-demo-with-firefly.html?utm_source=linkedin&utm_medium=social_nonpaid&utm_campaign=20_insights&utm_content=link_post&es_id=8e9abf83f6)
-- **Wunderman Thompson Technology** image reformatting: [How to generate intelligent renditions with AEM as a Cloud Service](https://tech.cognifide.com/blog/2020/how-to-generate-intelligent-renditions-aem-cloud/)
+- **Cognizant** demonstration airline website: [Building a Real-Time Airline Application Using Adobe Experience Platform, Adobe I/O Runtime and App Builder](https://www.netcentric.biz/insights/2020/06/building-an-aep-demo-with-firefly)
+- **Wunderman Thompson Technology** image reformatting: [How to generate intelligent renditions with AEM as a Cloud Service](https://wttech.blog/blog/2020/how-to-generate-intelligent-renditions-aem-cloud/)
 - **Adobe** Cloud Manager plug-in for Adobe I/O CLI: [Setting Up Adobe I/O CLI for Cloud Manager](https://medium.com/adobetech/setting-up-adobe-i-o-cli-for-cloud-manager-8820f47e3c94)
 - **VRT** dynamic content creation: [How Belgian Broadcaster VRT Turned to Adobe I/O Runtime to Dynamically Create Newsletter Content](https://medium.com/adobetech/how-belgian-broadcaster-vrt-turned-to-adobe-i-o-runtime-to-dynamically-create-newsletter-content-5cafe224a2a5)
 - **Bank of America** marketing offer personalization: [How Bank of America Is Using Adobe I/O Runtime to Boost the Efficiency of Its Personalized Offers in Adobe Target](https://medium.com/adobetech/how-bank-of-america-is-using-adobe-i-o-runtime-to-boost-the-efficiency-of-its-personalized-offers-699de38cf751)

--- a/src/pages/intro_and_overview/community.md
+++ b/src/pages/intro_and_overview/community.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Developer community
+description: 'How to join the App Builder Developer community and contribute to Adobe open-source projects.'
 ---
 
 # Developer Community

--- a/src/pages/intro_and_overview/faq.md
+++ b/src/pages/intro_and_overview/faq.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Frequently Asked Questions
+description: 'Frequently asked questions about App Builder, its use cases, pricing, and comparison with other application frameworks.'
 ---
 
 # Frequently Asked Questions

--- a/src/pages/intro_and_overview/index.md
+++ b/src/pages/intro_and_overview/index.md
@@ -1,3 +1,12 @@
+---
+keywords:
+  - Adobe I/O
+  - App Builder
+  - Overview
+title: 'App Builder Overview'
+description: 'Overview of the App Builder platform for building enterprise-grade Adobe Experience Cloud extensions on Adobe infrastructure.'
+---
+
 # App Builder Overview
 
 This documentation describes App Builder, a complete platform for enterprise Developers to build and deploy custom web applications. App Builder applications extend Adobe Experience Cloud solutions and run on Adobe infrastructure, including Adobe I/O Runtime, the serverless, event-driven, on-demand computing platform included with App Builder.

--- a/src/pages/intro_and_overview/release-notes.md
+++ b/src/pages/intro_and_overview/release-notes.md
@@ -1,3 +1,13 @@
+---
+keywords:
+  - Adobe I/O
+  - App Builder
+  - Release Notes
+  - Runtime
+title: 'Release Notes'
+description: 'Release notes for App Builder, Adobe I/O Runtime, and their associated CLI plugins and GitHub Actions.'
+---
+
 # Release Notes
 
 Stay up to date with the latest features, improvements, and bug fixes in App Builder and Adobe I/O Runtime.

--- a/src/pages/intro_and_overview/what-is-app-builder.md
+++ b/src/pages/intro_and_overview/what-is-app-builder.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation  
   - Developer Tooling
 title: How it Works
+description: 'What App Builder is, its main components, and how Adobe I/O Runtime fits into it.'
 ---
 
 ## What is App Builder?

--- a/src/pages/resources/asset-compute-worker-ps-api/lesson1.md
+++ b/src/pages/resources/asset-compute-worker-ps-api/lesson1.md
@@ -6,7 +6,7 @@ keywords:
   - Developer Tooling
 contributors:
   - 'https://github.com/duynguyen'
-title: 'Lesson 1: Create an App Builder app from the Asset Compute template'
+title: 'Lesson 1: Create an Asset Compute App Builder app'
 ---
 
 # Lesson 1: Create an App Builder App from the Asset Compute Template

--- a/src/pages/resources/asset-compute-worker-ps-api/lesson1.md
+++ b/src/pages/resources/asset-compute-worker-ps-api/lesson1.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 1: Create an Asset Compute App Builder app'
+description: 'Create an App Builder app from the Asset Compute template and add Photoshop API services.'
 ---
 
 # Lesson 1: Create an App Builder App from the Asset Compute Template

--- a/src/pages/resources/asset-compute-worker-ps-api/lesson2.md
+++ b/src/pages/resources/asset-compute-worker-ps-api/lesson2.md
@@ -10,7 +10,6 @@ title: 'Lesson 2: Configure the App'
 ---
 
 # Lesson 2: Configure the App
-# Lesson 2: Configure the App
 
 As you log in when creating the application, most of the App Builder credentials get collected in your `.env` file. However, using the Developer tool requires additional credentials.
 

--- a/src/pages/resources/asset-compute-worker-ps-api/lesson2.md
+++ b/src/pages/resources/asset-compute-worker-ps-api/lesson2.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 2: Configure the App'
+description: 'Configure cloud storage credentials and other settings required by the Asset Compute Developer tool.'
 ---
 
 # Lesson 2: Configure the App

--- a/src/pages/resources/asset-compute-worker-ps-api/lesson3.md
+++ b/src/pages/resources/asset-compute-worker-ps-api/lesson3.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 3: Develop custom worker calling Photoshop APIs'
+description: 'Develop a custom Asset Compute worker that calls Adobe Photoshop APIs to generate AEM Assets renditions.'
 ---
 
 # Lesson 3: Develop Custom Worker Calling Photoshop APIs

--- a/src/pages/resources/asset-compute-worker-ps-api/lesson3.md
+++ b/src/pages/resources/asset-compute-worker-ps-api/lesson3.md
@@ -31,7 +31,7 @@ You will need the [App Builder Files SDK](https://github.com/adobe/aio-lib-files
 
 Make sure you run `npm install` after updating the `package.json` file, so that all the npm modules are installed.
 
-Then update your action code in `actions/<worker-name>/index.js` to use the Photoshop API SDK. In this example, it calls the [Remove Background API](https://developer.adobe.com/firefly-services/docs/photoshop/api/photoshop_removeBackground/) to remove the background of an image.
+Then update your action code in `actions/<worker-name>/index.js` to use the Photoshop API SDK. In this example, it calls the Remove Background API (see the [Photoshop API reference](https://developer.adobe.com/firefly-services/docs/photoshop/api/)) to remove the background of an image.
 
 ```javascript
 const { worker, SourceCorruptError } = require('@adobe/asset-compute-sdk');

--- a/src/pages/resources/asset-compute-worker-ps-api/lesson4.md
+++ b/src/pages/resources/asset-compute-worker-ps-api/lesson4.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 4: Integrate and Use the Custom Worker in AEMaaCS'
+description: 'Deploy the custom Asset Compute worker and integrate it with AEM as a Cloud Service processing profiles.'
 ---
 
 # Lesson 4: Integrate and Use the Custom Worker in AEMaaCS

--- a/src/pages/resources/asset-compute-worker-ps-api/requirements.md
+++ b/src/pages/resources/asset-compute-worker-ps-api/requirements.md
@@ -17,4 +17,4 @@ In addition to above prerequisites, you'll need:
 
 * An AEM as a Cloud Service instance running in your IMS org
 * Photoshop API service already provisioned for your org.
-* [Understanding the working of a custom application in AEM Assets](https://experienceleague.adobe.com/docs/asset-compute/using/extend/custom-application-internals.html).
+* [Understanding the working of a custom application in AEM Assets](https://experienceleague.adobe.com/en/docs/asset-compute/using/extend/custom-application-internals).

--- a/src/pages/resources/asset-compute-worker-ps-api/requirements.md
+++ b/src/pages/resources/asset-compute-worker-ps-api/requirements.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: Codelab Environment Requirements
+description: 'Environment and account requirements for the Asset Compute worker with Photoshop APIs Code Lab.'
 ---
 
 <Fragment src="../transclusions/requirements.md"/>

--- a/src/pages/resources/asset-compute-worker-ps-api/welldone.md
+++ b/src/pages/resources/asset-compute-worker-ps-api/welldone.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: Well done
+description: 'Recap of the Asset Compute worker with Photoshop APIs Code Lab and the skills you learned.'
 ---
 
 # Well Done

--- a/src/pages/resources/barcode-reader/barcode.md
+++ b/src/pages/resources/barcode-reader/barcode.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 2: Writing a Serverless Action'
+description: 'Write a serverless action that generates a code128 barcode image using the bwip-js npm package.'
 ---
 
 # Lesson 2: Writing a Serverless Action

--- a/src/pages/resources/barcode-reader/bootstrap.md
+++ b/src/pages/resources/barcode-reader/bootstrap.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 1: Bootstrap a Headless App Builder App'
+description: 'Bootstrap a headless App Builder application for the barcode generator Code Lab using aio app init.'
 ---
 
 # Lesson 1: Bootstrap a Headless App Builder App

--- a/src/pages/resources/barcode-reader/requirements.md
+++ b/src/pages/resources/barcode-reader/requirements.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Requirements'
+description: 'Environment and account requirements for the headless barcode reader App Builder Code Lab.'
 ---
 
 <Fragment src="../transclusions/requirements.md"/>

--- a/src/pages/resources/barcode-reader/test.md
+++ b/src/pages/resources/barcode-reader/test.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 3: Testing a Serverless Action'
+description: 'Write Jest unit tests for the barcode-generation serverless action used in the headless App Builder Code Lab.'
 ---
 
 # Lesson 3: Testing a Serverless Action

--- a/src/pages/resources/barcode-reader/welldone.md
+++ b/src/pages/resources/barcode-reader/welldone.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Well done
+description: 'Recap of the headless barcode reader Code Lab and the App Builder skills you learned.'
 ---
 
 # Well Done

--- a/src/pages/resources/barcode-reader/welldone.md
+++ b/src/pages/resources/barcode-reader/welldone.md
@@ -8,7 +8,6 @@ title: Well done
 ---
 
 # Well Done
-# Well Done
 
 **You've reached the end**. This is all it takes to build an App Builder Headless App. Now you can use the barcode action, for example in an [email template inside Adobe Campaign](https://medium.com/adobetech/adobe-i-o-runtime-polishing-the-rough-edges-of-saas-solutions-238f82b58765).   
 

--- a/src/pages/resources/blog-articles.md
+++ b/src/pages/resources/blog-articles.md
@@ -142,7 +142,7 @@ Anil is a big advocate of App Builder for non-developers. He shares insights, ba
 
 ### From idea to app: building a real Adobe App Builder solution that extends Experience Cloud
 
-[Read on Experience League](https://experienceleague.adobe.com/en/perspectives/from-idea-to-app-building-a-real-adobe-app-builder-solution-that-extends-experience-cloud)
+[Read on Experience League](https://experienceleague.adobe.com/en/perspectives/from-idea-to-app-building-a-real-adobe-app-builder-solution-that-extends-cx-enterprise)
 
 Vadym built an App Builder app that automated Adobe Target impression-capping configuration from 45 minutes of manual work per activity to one click. The solution reduced operational effort from nearly an hour to seconds while ensuring consistent, governed execution directly in Experience Cloud.
 

--- a/src/pages/resources/ci-cd/lesson1.md
+++ b/src/pages/resources/ci-cd/lesson1.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 1: Setup CI/CD'
+description: 'Set up a CI/CD workflow for an App Builder application using GitHub Actions and the bundled Adobe I/O actions.'
 ---
 
 # Lesson 1: Setup CI/CD

--- a/src/pages/resources/ci-cd/lesson1.md
+++ b/src/pages/resources/ci-cd/lesson1.md
@@ -13,7 +13,7 @@ App Builder comes with pre-defined GitHub actions to manage your CI/CD workflow.
 
 ## Setup your GitHub repository for your App Builder App
 
-To put your App Builder App up on GitHub, you'll need to create a repository for it to live in. You can follow these [steps](https://help.github.com/en/github/getting-started-with-github/create-a-repo) to create an empty repository.
+To put your App Builder App up on GitHub, you'll need to create a repository for it to live in. You can follow these [steps](https://docs.github.com/en/repositories/creating-and-managing-repositories/quickstart-for-repositories) to create an empty repository.
 Once your repository is available on GitHub, you can copy your repository url e.g. `https://github.com/<org>/<project_name>.git`.
 
 Then in the command line, use `git clone https://github.com/<org>/<project_name>.git` to clone the repository to your local system.
@@ -33,7 +33,7 @@ By selecting the CI/CD workflow option, the application code will be initialized
 
 This folder contains default GitHub Workflows that can be customized and extended if needed. 
 
-**pr_test.yml** is the GitHub action that will run the App unit tests on the stage environment by calling `aio app test` against the requested changes. It will run anytime the [pull_request](https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request) event occurs.
+**pr_test.yml** is the GitHub action that will run the App unit tests on the stage environment by calling `aio app test` against the requested changes. It will run anytime the [pull_request](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows) event occurs.
 
 > Note: The versions in the example workflow files below (ex. @3) may not be the latest. We recommend updating to the newest major version when starting a new project, especially if setup is not working. To see the latest release, go to the Releases section of [adobe/aio-apps-action](https://github.com/adobe/aio-apps-action).
 
@@ -76,7 +76,7 @@ jobs:
 ```
 
 **deploy_stage.yml** is the GitHub action that will deploy the App Builder App to the stage environment on every new commit on the `master` branch by calling `aio app deploy`. 
-It will run anytime the [push](https://help.github.com/en/actions/reference/events-that-trigger-workflows#push-event-push) event occurs on the `master` branch. 
+It will run anytime the [push](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows) event occurs on the `master` branch. 
 
 ```yaml
 name: AIO App CI
@@ -122,7 +122,7 @@ jobs:
           AIO_RUNTIME_NAMESPACE: ${{ secrets.AIO_RUNTIME_NAMESPACE_STAGE }}
 ```
 
-**deploy_prod.yml** is the GitHub action that will deploy the App Builder App to the production environment by calling `aio app deploy`. It will run anytime the [release](https://help.github.com/en/actions/reference/events-that-trigger-workflows#release-event-release) event occurs. Please read [GitHub's documentation ](https://help.github.com/en/github/administering-a-repository/managing-releases-in-a-repository) to learn how to perform releases. 
+**deploy_prod.yml** is the GitHub action that will deploy the App Builder App to the production environment by calling `aio app deploy`. It will run anytime the [release](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows) event occurs. Please read [GitHub's documentation ](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) to learn how to perform releases. 
 
 ```yaml
 name: AIO App CI
@@ -179,7 +179,7 @@ The GitHub actions defined in `deploy_stage.yml` will run by default. Go to `htt
 
 ## GitHub secrets
 
-To differentiate Stage from Production environments, the GitHub actions rely on [GitHub secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets). Encrypted secrets allow you to store sensitive information, such as access tokens, in your repository. 
+To differentiate Stage from Production environments, the GitHub actions rely on [GitHub secrets](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets). Encrypted secrets allow you to store sensitive information, such as access tokens, in your repository. 
 
 By default, the secrets required for `deploy_prod.yml` for the **Production environment** are named: 
 
@@ -205,13 +205,13 @@ If you can't add secrets to the repository, possibilities include:
 * You don't have admin access for an organization repository
 * You don't have write access to the repository if you're using the [GitHub Actions secrets API](https://developer.github.com/v3/actions/secrets/#create-or-update-a-secret-for-a-repository)
 
-The secrets value can be retrieved in the [Developer Console](https://console.adobe.io/), from which you can download  Stage and Production namespaces and credentials.
+The secrets value can be retrieved in the [Developer Console](https://developer.adobe.com/console/), from which you can download  Stage and Production namespaces and credentials.
 
 ![developer-console](assets/developer-console.png)  
 
 Follow these steps to retrieve the value for the secrets: `AIO_RUNTIME_NAMESPACE_STAGE`, `AIO_RUNTIME_AUTH_STAGE` and `AIO_RUNTIME_NAMESPACE_PROD`, `AIO_RUNTIME_AUTH_PRD`: 
 
-1. Go to the [Developer Console](https://console.adobe.io/)
+1. Go to the [Developer Console](https://developer.adobe.com/console/)
 2. Select the right org, project and workspace
 3. Click on the Download all button on the top right 
 

--- a/src/pages/resources/ci-cd/lesson2.md
+++ b/src/pages/resources/ci-cd/lesson2.md
@@ -50,4 +50,4 @@ Finally, the Deploy GitHub action will run and deploy the App Builder App on the
 
 GitHub Actions provide cloud based CI/CD features; therefore you can't debug jobs locally. GitHub provides tools to help you debug failing jobs.
 
-Please find more information on how to view run logs, enable verbose logs, and more in the [GitHub documentation](https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs).   
+Please find more information on how to view run logs, enable verbose logs, and more in the [GitHub documentation](https://docs.github.com/en/actions/how-tos/manage-workflow-runs).   

--- a/src/pages/resources/ci-cd/lesson2.md
+++ b/src/pages/resources/ci-cd/lesson2.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 2: Monitoring CI/CD'
+description: 'Monitor and debug failing GitHub Actions workflows for an App Builder application.'
 ---
 
 # Lesson 2: Monitoring CI/CD

--- a/src/pages/resources/ci-cd/lesson3.md
+++ b/src/pages/resources/ci-cd/lesson3.md
@@ -11,7 +11,7 @@ title: 'Lesson 3: Custom CI/CD workflow'
 
 ## Setting environment variables
 
-You can add additional environment variables to the test and deploy GitHub workflows see the [GitHub documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables) for more information.
+You can add additional environment variables to the test and deploy GitHub workflows see the [GitHub documentation](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables) for more information.
 
 In our case, if you want to add for example environment values named `MY_ENV_VALUE_1` and `MY_ENV_VALUE_2` to the stage and production deploy workflow, follow these steps:
 

--- a/src/pages/resources/ci-cd/lesson3.md
+++ b/src/pages/resources/ci-cd/lesson3.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 3: Custom CI/CD workflow'
+description: 'Customize CI/CD workflows for an App Builder application with extra environment variables and steps.'
 ---
 
 # Lesson 3: Custom CI/CD workflow

--- a/src/pages/resources/ci-cd/requirements.md
+++ b/src/pages/resources/ci-cd/requirements.md
@@ -13,5 +13,5 @@ title: Codelab Environment Requirements
 
 You should also have a GitHub account: 
 
-* [Creating your GitHub account](https://help.github.com/en/github/getting-started-with-github/signing-up-for-a-new-github-account)
+* [Creating your GitHub account](https://docs.github.com/en/get-started/start-your-journey/creating-an-account-on-github)
 * [Installing a Git client](https://git-scm.com/downloads)

--- a/src/pages/resources/ci-cd/requirements.md
+++ b/src/pages/resources/ci-cd/requirements.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Codelab Environment Requirements
+description: 'Environment, GitHub account, and tooling requirements for the CI/CD Code Lab.'
 ---
 
 <Fragment src="../transclusions/requirements.md"/>

--- a/src/pages/resources/ci-cd/welldone.md
+++ b/src/pages/resources/ci-cd/welldone.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Well done
+description: 'Recap of the CI/CD Code Lab and the GitHub Actions skills you learned for App Builder applications.'
 ---
 
 # Well Done

--- a/src/pages/resources/cron-jobs/lesson1.md
+++ b/src/pages/resources/cron-jobs/lesson1.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 1: Bootstrap a Headless App'
+description: 'Bootstrap a headless App Builder application to be triggered on a schedule by an alarm feed.'
 ---
 
 # Lesson 1: Bootstrap a Headless App

--- a/src/pages/resources/cron-jobs/lesson2.md
+++ b/src/pages/resources/cron-jobs/lesson2.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 2: Set up Alarm Feed with Trigger and Rule'
+description: 'Set up an alarm feed with a trigger and rule to invoke an App Builder action on an interval schedule.'
 ---
 
 # Lesson 2: Set up Alarm Feed with Trigger and Rule

--- a/src/pages/resources/cron-jobs/lesson3.md
+++ b/src/pages/resources/cron-jobs/lesson3.md
@@ -31,7 +31,7 @@ Note that `YYYY-MM-DDTHH:mm:ss.sssZ` is just a format for this field; you are fr
 
 ## Firing a trigger on a time-based schedule using cron
 
-The `/whisk.system/alarms/alarm` feed allows you to [fire an event on a time-based schedule using cron](https://github.com/apache/openwhisk-package-alarms#firing-a-trigger-on-a-time-based-schedule-using-cron). This is more generic than the `interval` and `once` feeds, because you can write crontab to configure the alarm service to trigger at the exact time and interval you want. The only required parameter is `cron`, a string based on the [UNIX crontab syntax](http://crontab.org) that indicates when to fire the trigger in UTC. Optional params are `trigger_payload`, `startDate` and `stopDate`.
+The `/whisk.system/alarms/alarm` feed allows you to [fire an event on a time-based schedule using cron](https://github.com/apache/openwhisk-package-alarms#firing-a-trigger-on-a-time-based-schedule-using-cron). This is more generic than the `interval` and `once` feeds, because you can write crontab to configure the alarm service to trigger at the exact time and interval you want. The only required parameter is `cron`, a string based on the [UNIX crontab syntax](https://crontab.guru/) that indicates when to fire the trigger in UTC. Optional params are `trigger_payload`, `startDate` and `stopDate`.
 
 <InlineAlert variant="warning" slots="text" />
 

--- a/src/pages/resources/cron-jobs/lesson3.md
+++ b/src/pages/resources/cron-jobs/lesson3.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 3: Types of Alarm Feed'
+description: 'Use other alarm feed types in Adobe I/O Runtime to fire triggers once or on a cron schedule.'
 ---
 
 # Lesson 3: Types of Alarm Feed

--- a/src/pages/resources/cron-jobs/requirements.md
+++ b/src/pages/resources/cron-jobs/requirements.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: Codelab Environment Requirements
+description: 'Environment requirements for the App Builder cron jobs and alarm feeds Code Lab.'
 ---
 
 <Fragment src="../transclusions/requirements.md"/>

--- a/src/pages/resources/cron-jobs/welldone.md
+++ b/src/pages/resources/cron-jobs/welldone.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: Well done
+description: 'Recap of the cron jobs Code Lab and the App Builder scheduler skills you learned.'
 ---
 
 # Well Done

--- a/src/pages/resources/custom-asset-compute-worker/aem-cloud-assets.md
+++ b/src/pages/resources/custom-asset-compute-worker/aem-cloud-assets.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/marcinczeczko'
 title: How AEM as Cloud Aassets Works
+description: 'How AEM as a Cloud Service handles asset binaries and where Asset Compute custom workers fit in.'
 ---
 
 # How AEM as Cloud Assets Works

--- a/src/pages/resources/custom-asset-compute-worker/index.md
+++ b/src/pages/resources/custom-asset-compute-worker/index.md
@@ -22,5 +22,5 @@ Image resizing or format conversion is a relatively easy task when doing renditi
 Your project might require more robust approaches supported by intelligent image services. For example, you might need to change images to greyscale, or intelligently crop the images around faces. 
 
 This Code Lab will guide you through the creating a [custom worker for Asset Compute][asset-compute-extensions] using App Builder, and how to use it in [Adobe Experience Manager as a Cloud service][aem-cloud].
-[asset-compute-extensions]: https://docs.adobe.com/content/help/en/asset-compute/using/extend/understand-extensibility.html
-[aem-cloud]: https://docs.adobe.com/content/help/en/experience-manager-cloud-service/landing/home.html
+[asset-compute-extensions]: https://experienceleague.adobe.com/en/docs/asset-compute/using/extend/understand-extensibility
+[aem-cloud]: https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/overview/introduction

--- a/src/pages/resources/custom-asset-compute-worker/lesson1.md
+++ b/src/pages/resources/custom-asset-compute-worker/lesson1.md
@@ -49,8 +49,8 @@ To test your configuration:
    pair** and your keys will be downloaded as a zip file.
 4. Unzip the file and write down the location to the **private.key**.
 
-[create-azure-blob]: https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal 'Create storage account and container'
+[create-azure-blob]: https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal 'Create storage account and container'
 [imgix-create-azure-source]: https://docs.imgix.com/setup/creating-sources/microsoft-azure 'Setting up your Microsoft Azure Source'
 [imgix-tools]: https://dashboard.imgix.com/tools
-[adobe-console]: https://console.adobe.io 'Adobe IO Console'
+[adobe-console]: https://developer.adobe.com/console/ 'Adobe IO Console'
 [adobe-console-firefly-template]: ../../get_started/app_builder_get_started/first-app.md#2-creating-a-new-project-on-developer-console 'Creating new project on Adobe Developer console'

--- a/src/pages/resources/custom-asset-compute-worker/lesson1.md
+++ b/src/pages/resources/custom-asset-compute-worker/lesson1.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/marcinczeczko'
 title: 'Lesson 1: Configure Services'
+description: 'Configure Azure blob storage, imgIX, and Adobe I/O services for the custom Asset Compute worker Code Lab.'
 ---
 
 # Lesson 1: Configure Services

--- a/src/pages/resources/custom-asset-compute-worker/lesson1.md
+++ b/src/pages/resources/custom-asset-compute-worker/lesson1.md
@@ -10,9 +10,7 @@ title: 'Lesson 1: Configure Services'
 ---
 
 # Lesson 1: Configure Services
-# Lesson 1: Configure Services
 
-## Create Azure blob storage
 ## Create Azure blob storage
 
 You need to [create Azure blob storage][create-azure-blob] on your Azure account. Then, create two containers:
@@ -37,7 +35,6 @@ To test your configuration:
    `https://<your-subdomain>.imgix.net/image.png`
 3. Open the signed URL in the browser to verify the image is loaded
 
-## Configure Adobe I/O
 ## Configure Adobe I/O
 
 1. Go to the [https://console.adobe.io][adobe-console] and create a [new project using App Builder template][adobe-console-firefly-template].

--- a/src/pages/resources/custom-asset-compute-worker/lesson2.md
+++ b/src/pages/resources/custom-asset-compute-worker/lesson2.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/marcinczeczko'
 title: 'Lesson 2: Local environment setup'
+description: 'Install the aio CLI and prepare the local environment for the custom Asset Compute worker Code Lab.'
 ---
 
 # Lesson 2: Local Environment Setup

--- a/src/pages/resources/custom-asset-compute-worker/lesson3.md
+++ b/src/pages/resources/custom-asset-compute-worker/lesson3.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/marcinczeczko'
 title: 'Lesson 3: Implement the worker'
+description: 'Implement a custom Asset Compute worker that produces renditions using the imgIX service.'
 ---
 
 # Lesson 3: Implement the Worker

--- a/src/pages/resources/custom-asset-compute-worker/lesson4.md
+++ b/src/pages/resources/custom-asset-compute-worker/lesson4.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/marcinczeczko'
 title: 'Lesson 4: Test the worker'
+description: 'Test a custom Asset Compute worker locally using the Asset Compute Developer tool.'
 ---
 
 # Lesson 4: Test the Worker

--- a/src/pages/resources/custom-asset-compute-worker/lesson5.md
+++ b/src/pages/resources/custom-asset-compute-worker/lesson5.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/marcinczeczko'
 title: 'Lesson 5: Setup AEM to use the worker'
+description: 'Configure AEM as a Cloud Service to use a custom Asset Compute worker via processing profiles.'
 ---
 
 # Lesson 5: Set Up AEM to Use the Worker

--- a/src/pages/resources/custom-asset-compute-worker/our-worker.md
+++ b/src/pages/resources/custom-asset-compute-worker/our-worker.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/marcinczeczko'
 title: Architecture of our worker
+description: 'Architecture of a custom Asset Compute worker that produces renditions using imgIX and Azure blob storage.'
 ---
 
 # Architecture of Our Worker

--- a/src/pages/resources/custom-asset-compute-worker/requirements.md
+++ b/src/pages/resources/custom-asset-compute-worker/requirements.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/marcinczeczko'
 title: Codelab Environment Requirements
+description: 'Environment, third-party service, and account requirements for the custom Asset Compute worker Code Lab.'
 ---
 
 <Fragment src="../transclusions/requirements.md"/>

--- a/src/pages/resources/custom-asset-compute-worker/welldone.md
+++ b/src/pages/resources/custom-asset-compute-worker/welldone.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/marcinczeczko'
 title: Well done
+description: 'Recap of the custom Asset Compute worker Code Lab and the intelligent rendition skills you learned.'
 ---
 
 # Well Done

--- a/src/pages/resources/customer-dashboard/index.md
+++ b/src/pages/resources/customer-dashboard/index.md
@@ -20,7 +20,7 @@ App Builder is a complete platform that enables enterprise Developers to build a
 
 [Adobe Campaign Standard (ACS)](https://www.adobe.com/marketing/campaign.html) provides a platform for designing and executing digital marketing campaigns and provides an environment for visual campaign orchestration  
 
-[Campaign Standard APIs](https://docs.adobe.com/content/help/en/campaign-standard/using/working-with-apis/about-campaign-standard-apis/about-campaign-standard-apis.html) let you create integrations for Adobe Campaign Standard and build your own ecosystem by interfacing Adobe Campaign Standard with the panel of technologies that you use.
+[Campaign Standard APIs](https://experienceleague.adobe.com/en/docs/campaign-standard/using/working-with-apis/get-started-apis) let you create integrations for Adobe Campaign Standard and build your own ecosystem by interfacing Adobe Campaign Standard with the panel of technologies that you use.
 
 In this lab, you will learn how to:
 

--- a/src/pages/resources/customer-dashboard/lesson1.md
+++ b/src/pages/resources/customer-dashboard/lesson1.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 1: Create an App from the Campaign Standard Template'
+description: 'Create an App Builder application from the Adobe Campaign Standard template for the customer dashboard Code Lab.'
 ---
 
 # Lesson 1: Create a New App Builder App from Campaign Standard Template

--- a/src/pages/resources/customer-dashboard/lesson1.md
+++ b/src/pages/resources/customer-dashboard/lesson1.md
@@ -6,7 +6,7 @@ keywords:
   - Developer Tooling
 contributors:
   - 'https://github.com/duynguyen'
-title: 'Lesson 1: Create a New App Builder App from Campaign Standard Template'
+title: 'Lesson 1: Create an App from the Campaign Standard Template'
 ---
 
 # Lesson 1: Create a New App Builder App from Campaign Standard Template

--- a/src/pages/resources/customer-dashboard/lesson2.md
+++ b/src/pages/resources/customer-dashboard/lesson2.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 2: Explore the App Builder App'
+description: 'Explore the file structure, manifest, and credentials of a Campaign Standard App Builder application.'
 ---
 
 # Lesson 2: Explore the App Builder App

--- a/src/pages/resources/customer-dashboard/lesson2.md
+++ b/src/pages/resources/customer-dashboard/lesson2.md
@@ -13,7 +13,7 @@ title: 'Lesson 2: Explore the App Builder App'
 
 Within the newly created app, you have seen the `.env` file with your credentials for running the app. 
 
-`package.json` is the [crucial part](https://docs.npmjs.com/creating-a-package-json-file) of almost every NodeJS project. It contains the list of dependencies, version, reproducible builds, and so on.
+`package.json` is the [crucial part](https://docs.npmjs.com/creating-a-package-json-file/) of almost every NodeJS project. It contains the list of dependencies, version, reproducible builds, and so on.
 
 `ext.config.yaml` in the `src/dx-excshell-1/` folder is the cockpit of your App Builder app back end. It lists the declaration of serverless actions including name, source files, runtime kind, default parameters, annotations, and so on. You can find the grammar of writing manifest [here](https://github.com/apache/openwhisk-wskdeploy/blob/master/docs/programming_guide.md#wskdeploy-utility-by-example):
 
@@ -113,7 +113,7 @@ exports.main = main
 
 Here, the [action](https://github.com/apache/openwhisk/blob/master/docs/actions-nodejs.md) exposes a `main` function, which accepts a list of parameters from the client. It checks that required parameters for using the Campaign Standard SDK are present in the list, including the `Authorization` header for authentication against Adobe IMS.
 
-An access token is retrieved to initiate the SDK client instance, which is then used to retrieve the list of customer profiles using the [getAllProfiles()](https://docs.adobe.com/content/help/en/campaign-standard/using/working-with-apis/managing-profiles/retrieving-profiles.html) function. Finally, the profiles are returned to the client. The entire execution is wrapped within a try-catch block, so errors are handled appropriately.
+An access token is retrieved to initiate the SDK client instance, which is then used to retrieve the list of customer profiles using the [getAllProfiles()](https://experienceleague.adobe.com/en/docs/campaign-standard/using/working-with-apis/managing-profiles/retrieving-profiles) function. Finally, the profiles are returned to the client. The entire execution is wrapped within a try-catch block, so errors are handled appropriately.
 
 Next, let's see how the web UI communicates with the back end. All web assets are placed in the `src/dx-excshell-1/web-src` folder.
 

--- a/src/pages/resources/customer-dashboard/lesson3.md
+++ b/src/pages/resources/customer-dashboard/lesson3.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 3: Run the App Builder App Locally'
+description: 'Run a Campaign Standard App Builder application locally with aio app run and accept the self-signed certificate.'
 ---
 
 # Lesson 3: Run the App Builder App Locally

--- a/src/pages/resources/customer-dashboard/lesson4.md
+++ b/src/pages/resources/customer-dashboard/lesson4.md
@@ -11,7 +11,7 @@ title: 'Lesson 4: List All Customer Profiles on the UI'
 
 # Lesson 4: List All Customer Profiles on the UI
 
-The app UI is powered by [React Spectrum](https://react-spectrum.adobe.com/react-spectrum/index.html) by default. To learn more about React Spectrum, please consult the [React Spectrum Code Lab](../todo-app/index.md).  
+The app UI is powered by [React Spectrum](https://react-spectrum.adobe.com/) by default. To learn more about React Spectrum, please consult the [React Spectrum Code Lab](../todo-app/index.md).  
 
 In the [previous lesson](lesson3.md), customer profiles were loaded to the front end only when you click the "Invoke" button. Now we want the profiles loaded automatically on the Home page when the page is ready, with no human interaction. 
 

--- a/src/pages/resources/customer-dashboard/lesson4.md
+++ b/src/pages/resources/customer-dashboard/lesson4.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 4: List All Customer Profiles on the UI'
+description: 'Use React Spectrum to display a list of customer profiles loaded from Adobe Campaign Standard on the App Builder UI.'
 ---
 
 # Lesson 4: List All Customer Profiles on the UI

--- a/src/pages/resources/customer-dashboard/lesson5.md
+++ b/src/pages/resources/customer-dashboard/lesson5.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 5: Add Personalized Promotion Emails Triggering'
+description: 'Add personalized promotion email triggering to the customer dashboard using a new Runtime action and uuid barcode.'
 ---
 
 # Lesson 5: Add Personalized Promotion Emails Triggering

--- a/src/pages/resources/customer-dashboard/requirements.md
+++ b/src/pages/resources/customer-dashboard/requirements.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: Codelab Environment Requirements
+description: 'Environment and Adobe Campaign Standard requirements for the customer dashboard Code Lab.'
 ---
 
 <Fragment src="../transclusions/requirements.md"/>

--- a/src/pages/resources/customer-dashboard/welldone.md
+++ b/src/pages/resources/customer-dashboard/welldone.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: Well done
+description: 'Recap of the customer dashboard Code Lab and the Campaign Standard skills you learned.'
 ---
 
 # Well Done

--- a/src/pages/resources/debugging/lesson1.md
+++ b/src/pages/resources/debugging/lesson1.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 1: Getting Familiar with Debugger'
+description: 'Get familiar with wskdebug and the VS Code launch profiles generated for App Builder applications.'
 ---
 
 # Lesson 1: Getting to know wskdebug

--- a/src/pages/resources/debugging/lesson2.md
+++ b/src/pages/resources/debugging/lesson2.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 2: Debugging Application Code'
+description: 'Debug App Builder application code inside the Experience Cloud Shell using VS Code breakpoints.'
 ---
 
 # Lesson 2: Debugging Application Code

--- a/src/pages/resources/debugging/lesson3.md
+++ b/src/pages/resources/debugging/lesson3.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: 'Lesson 3: Managing Application Logs'
+description: 'Manage application logs in App Builder applications using the core Logging library and LOG_LEVEL input.'
 ---
 
 # Lesson 3: Managing Application Logs

--- a/src/pages/resources/debugging/requirements.md
+++ b/src/pages/resources/debugging/requirements.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: Codelab Environment Requirements
+description: 'Environment requirements for the App Builder debugging Code Lab, including Visual Studio Code.'
 ---
 
 <Fragment src="../transclusions/requirements.md"/>

--- a/src/pages/resources/debugging/welldone.md
+++ b/src/pages/resources/debugging/welldone.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/duynguyen'
 title: Well done
+description: 'Recap of the debugging Code Lab and the VS Code debugging skills you learned for App Builder applications.'
 ---
 
 # Well done

--- a/src/pages/resources/event-driven/lesson1.md
+++ b/src/pages/resources/event-driven/lesson1.md
@@ -24,7 +24,7 @@ To use the custom events CLI plugin, you need this information from the console 
 - `Config.zip`: Configuration file downloaded from the console, including `private key` and `certificate_pub.crt`
 
 - `project.json`: For instance, the `projectname-orgId-Production.json` file downloaded from the console 
-1. Navigate to the Adobe I/O console at [https://console.adobe.io](https://console.adobe.io) in your browser and create a project using an App Builder template, or use your existing project .
+1. Navigate to the Adobe I/O console at [https://developer.adobe.com/console/](https://developer.adobe.com/console/) in your browser and create a project using an App Builder template, or use your existing project .
 
 2. Select `Add to Project` -> `Add an API` -> `Adobe Services` -> `I/O managemenet API`.
 

--- a/src/pages/resources/event-driven/lesson1.md
+++ b/src/pages/resources/event-driven/lesson1.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: 'Lesson 1: Create a New App Builder App from Template'
+description: 'Create an App Builder application from a template for the event-driven Code Lab, including required Console services.'
 ---
 
 # Lesson 1: Create a New App Builder App from Template

--- a/src/pages/resources/event-driven/lesson2.md
+++ b/src/pages/resources/event-driven/lesson2.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: 'Lesson 2: Register the App as Event Provider'
+description: 'Register an App Builder application as a custom event provider using the Adobe I/O Events CLI plugin.'
 ---
 
 # Lesson 2: Register the App as an Event Provider

--- a/src/pages/resources/event-driven/lesson3.md
+++ b/src/pages/resources/event-driven/lesson3.md
@@ -161,7 +161,7 @@ You will see your deployed link in the terminal.
 Next, let's see how the web UI communicates with the back end. In `web-src/src/components` we already provided a template of the UI.
 After you select the actions to `publish-events`, clicking the `invoke` button will invoke the action. The action will send out the event. When you invoke, you could also add actual parameters. In this example we added `{"payload": "you got a like"}` In the webhook result, you will see the payload: `{"data": "you got a like"}`.
 
-> Note: This example uses [this webhook tool](https://io-webhook.herokuapp.com/) to generate a webhook link and put the webhook to the console integration. You can use other tools, as discussed in the next lesson. 
+> Note: This example uses a webhook inspector tool such as [Webhook.site](https://webhook.site/) to generate a webhook URL and put the webhook to the console integration. You can use other tools, as discussed in the next lesson. 
 
 ![templateui](assets/template-ui.png)
 

--- a/src/pages/resources/event-driven/lesson3.md
+++ b/src/pages/resources/event-driven/lesson3.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: 'Lesson 3: Fire an Event'
+description: 'Fire a custom event from an App Builder action using publish-event and the Adobe I/O Events SDK.'
 ---
 
 # Lesson 3: Fire an Event

--- a/src/pages/resources/event-driven/lesson4.md
+++ b/src/pages/resources/event-driven/lesson4.md
@@ -22,7 +22,7 @@ There are three ways one can consume event:
 
 Adobe offers journaling to consume events. The Adobe I/O Events Journaling API lets enterprise integrations consume events at their own cadence and process them in bulk. Unlike webhooks, no additional registration or other configuration is required. Every enterprise integration that is registered for events is automatically enabled for journaling. Journaling data is retained for 7 days. 
 
-After you fire an event, you should be able to verify it by journaling the `UNIQUE API ENDPOINT` you get from the console by following the instructions in the Adobe I/O Events documentation: [Journaling API](https://developer.adobe.com/events/docs/guides/api/journaling_api/).
+After you fire an event, you should be able to verify it by journaling the `UNIQUE API ENDPOINT` you get from the console by following the instructions in the [Adobe I/O Events API documentation](https://developer.adobe.com/events/docs/guides/api/).
 
 You could also use the `Curl` command or `POSTMAN` to call the journaling `UNIQUE API ENDPOINT` to see your fired event. Or you could use [Custom event SDK](https://github.com/adobe/aio-lib-events/) to call the Journaling API and retrieve your event.
 

--- a/src/pages/resources/event-driven/lesson4.md
+++ b/src/pages/resources/event-driven/lesson4.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: 'Lesson 4: Consume Events'
+description: 'Consume Adobe I/O Events from an App Builder application using the Journaling API, Runtime actions, or webhooks.'
 ---
 
 # Lesson 4: Consume Events

--- a/src/pages/resources/event-driven/requirements.md
+++ b/src/pages/resources/event-driven/requirements.md
@@ -19,6 +19,6 @@ In addition to the prerequisites listed above, please install the [Adobe I/O Eve
 npm install -g @adobe/aio-cli-plugin-events
 ```
 
-We assume that you have access and authorization to create integrations on [Adobe I/O Console](https://console.adobe.io/).  `I/O Management Service` needs to be enabled for the integration. This will help create the JWT token with adobeio_api scope that is required for all the API calls.
+We assume that you have access and authorization to create integrations on [Adobe I/O Console](https://developer.adobe.com/console/).  `I/O Management Service` needs to be enabled for the integration. This will help create the JWT token with adobeio_api scope that is required for all the API calls.
 
 ![webhook](assets/event.png)

--- a/src/pages/resources/event-driven/requirements.md
+++ b/src/pages/resources/event-driven/requirements.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: Codelab Environment Requirements
+description: 'Environment, Console, and aio CLI Events plugin requirements for the event-driven App Builder Code Lab.'
 ---
 
 <Fragment src="../transclusions/requirements.md"/>

--- a/src/pages/resources/event-driven/welldone.md
+++ b/src/pages/resources/event-driven/welldone.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: Well done
+description: 'Recap of the event-driven App Builder Code Lab and the I/O Events skills you learned.'
 ---
 
 # Well Done

--- a/src/pages/resources/events-runtime/lesson1.md
+++ b/src/pages/resources/events-runtime/lesson1.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: 'Lesson 1: Step by Step Guide'
+description: 'Initialize an App Builder application and register an event provider for the Runtime actions webhook Code Lab.'
 ---
 
 # Lesson 1: Initialize an App Builder App Using a Template

--- a/src/pages/resources/events-runtime/lesson2.md
+++ b/src/pages/resources/events-runtime/lesson2.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: 'Lesson 2: Verify the result'
+description: 'Verify event provider behavior by tracing actions with Activation IDs in the Adobe Developer Console.'
 ---
 
 # Lesson 2: Verify the Result

--- a/src/pages/resources/events-runtime/requirements.md
+++ b/src/pages/resources/events-runtime/requirements.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: Codelab Environment Requirements
+description: 'Environment requirements and supporting documents for the Runtime actions webhook Code Lab.'
 ---
 
 <Fragment src="../transclusions/requirements.md"/>

--- a/src/pages/resources/events-runtime/welldone.md
+++ b/src/pages/resources/events-runtime/welldone.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: Well done
+description: 'Recap of the Runtime actions webhook Code Lab and the debug tracing skills you learned.'
 ---
 
 ## Well Done

--- a/src/pages/resources/index.md
+++ b/src/pages/resources/index.md
@@ -115,7 +115,7 @@ Building a Custom Asset Compute Worker using third-party services to generate in
 
 ### Build an app that consumes Adobe Experience Manager events
 
-[Start (30 min)](https://experienceleague.adobe.com/docs/adobe-developers-live-events/events/2021/oct2021/consume-aem-events.html?lang=en)
+[Start (30 min)](https://experienceleague.adobe.com/en/docs/events/adobe-developers-live-recordings/overview)
 
 Learn why is it a good idea to build event-driven applications and how to build them with ease using App Builder.
 

--- a/src/pages/resources/journaling-events/index.md
+++ b/src/pages/resources/journaling-events/index.md
@@ -22,7 +22,7 @@ There is a class of App Builder apps for which customers want guarantees that I/
 
 ## Solution
 
-- Use the [Journaling API](https://developer.adobe.com/events/docs/guides/api/journaling_api/) to retrieve events instead of relying on the webhook approach.
+- Use the [Journaling API](https://developer.adobe.com/events/docs/guides/api/) to retrieve events instead of relying on the webhook approach.
 - Use a Runtime action that uses the [Alarm package](../cron-jobs/index.md) to read the events every X minutes.
 - The alarm action stores the events in the App Builder storage [aio-lib-state](https://github.com/adobe/aio-lib-state)
 - Record an index of events in storage so that if the action fails, the next invocation will retrieve from the same index, and no events will be lost.

--- a/src/pages/resources/journaling-events/lesson1.md
+++ b/src/pages/resources/journaling-events/lesson1.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: 'Lesson 1: Create an Event Provider using App Builder'
+description: 'Create an event provider using App Builder and the OpenWhisk Alarms package for the Journaling API Code Lab.'
 ---
 
 # Lesson 1: Create an Event Provider using App Builder

--- a/src/pages/resources/journaling-events/lesson2.md
+++ b/src/pages/resources/journaling-events/lesson2.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: 'Lesson 2: Create the Event Consumer using Journaling API'
+description: 'Create an event consumer using the Journaling API and store events with aio-lib-state.'
 ---
 
 # Lesson 2: Create an Event Consumer using the Journaling API

--- a/src/pages/resources/journaling-events/lesson3.md
+++ b/src/pages/resources/journaling-events/lesson3.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: 'Lesson 3: End to end test'
+description: 'Run an end-to-end test of the Journaling API event provider and consumer apps on different alarm schedules.'
 ---
 
 # Lesson 3: End-to-End Test

--- a/src/pages/resources/journaling-events/requirements.md
+++ b/src/pages/resources/journaling-events/requirements.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: Codelab Environment Requirements
+description: 'Environment requirements and supporting documents for the Journaling API App Builder Code Lab.'
 ---
 
 <Fragment src="../transclusions/requirements.md"/>

--- a/src/pages/resources/journaling-events/welldone.md
+++ b/src/pages/resources/journaling-events/welldone.md
@@ -7,6 +7,7 @@ keywords:
 contributors:
   - 'https://github.com/Yu1986'
 title: Well done
+description: 'Recap of the Journaling API Code Lab and the high-availability event consumer skills you learned.'
 ---
 
 # Well Done

--- a/src/pages/resources/sample_apps/code_snippets/analytics.md
+++ b/src/pages/resources/sample_apps/code_snippets/analytics.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Code Snippets: Real-time Adobe Analytics API 1.4'
+description: 'Sample App Builder action that demonstrates how to access Adobe Analytics Real-time API 1.4.'
 ---
 
 # Real-Time Data from Adobe Analytics API 1.4

--- a/src/pages/resources/sample_apps/code_snippets/analytics.md
+++ b/src/pages/resources/sample_apps/code_snippets/analytics.md
@@ -4,7 +4,7 @@ keywords:
   - Extensibility
   - API Documentation
   - Developer Tooling
-title: App Builder Code Snippets - Real-time data from Adobe Analytics API 1.4  
+title: 'Code Snippets: Real-time Adobe Analytics API 1.4'
 ---
 
 # Real-Time Data from Adobe Analytics API 1.4

--- a/src/pages/resources/sample_apps/code_snippets/events.md
+++ b/src/pages/resources/sample_apps/code_snippets/events.md
@@ -4,7 +4,8 @@ keywords:
   - Extensibility
   - API Documentation
   - Developer Tooling
-title: App Builder Code Snippets - I/O Events handler  
+title: App Builder Code Snippets - I/O Events handler
+description: 'Sample App Builder action that demonstrates how to write an I/O Events handler for webhook calls.'
 ---
 
 # I/O Events Handler

--- a/src/pages/resources/sample_apps/code_snippets/files.md
+++ b/src/pages/resources/sample_apps/code_snippets/files.md
@@ -4,7 +4,8 @@ keywords:
   - Extensibility
   - API Documentation
   - Developer Tooling
-title: App Builder Code Snippets - App Builder Files SDK  
+title: App Builder Code Snippets - App Builder Files SDK
+description: 'Sample App Builder action that demonstrates how to return a list of files stored with the Files SDK.'
 ---
 
 # App Builder Files SDK

--- a/src/pages/resources/sample_apps/code_snippets/index.md
+++ b/src/pages/resources/sample_apps/code_snippets/index.md
@@ -4,7 +4,8 @@ keywords:
   - Extensibility
   - API Documentation
   - Developer Tooling
-title: App Builder Code Snippets - Caching HTTP responses  
+title: App Builder Code Snippets - Caching HTTP responses
+description: 'Sample App Builder action that demonstrates how to cache an action''s HTTP response at the gateway level.'
 ---
 
 # Caching HTTP responses

--- a/src/pages/resources/sample_apps/code_snippets/state.md
+++ b/src/pages/resources/sample_apps/code_snippets/state.md
@@ -4,7 +4,8 @@ keywords:
   - Extensibility
   - API Documentation
   - Developer Tooling
-title: App Builder Code Snippets - App Builder State SDK  
+title: App Builder Code Snippets - App Builder State SDK
+description: 'Sample App Builder action that demonstrates how to read a value by key from the State SDK.'
 ---
 
 # App Builder State SDK

--- a/src/pages/resources/sample_apps/demo.md
+++ b/src/pages/resources/sample_apps/demo.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title:  App Builder Demo App
+description: 'Adobe Stock image search demo app built with App Builder.'
 ---
 
 <iframe/>

--- a/src/pages/resources/sample_apps/index.md
+++ b/src/pages/resources/sample_apps/index.md
@@ -4,7 +4,8 @@ keywords:
   - Extensibility
   - API Documentation
   - Developer Tooling
-title: App Builder Sample Apps  
+title: App Builder Sample Apps
+description: 'Sample App Builder applications and code snippets for common operations, ready to clone and adapt.'
 ---
 
 # Sample Apps

--- a/src/pages/resources/spectrum-intro/lesson1.md
+++ b/src/pages/resources/spectrum-intro/lesson1.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 1: Introduction to Spectrum'
+description: 'Introduction to Adobe''s Spectrum design system and its goals for consistent, accessible experiences across Adobe products.'
 ---
 
 # Lesson 1: Introduction to Spectrum

--- a/src/pages/resources/spectrum-intro/lesson1.md
+++ b/src/pages/resources/spectrum-intro/lesson1.md
@@ -38,7 +38,7 @@ Spectrum connects different talents, viewpoints, and skills into something that 
 
 ### Adobe Clean Font families
 
-To use the Adobe Clean font families, download them through the [Adobe Developer Console](https://console.adobe.io/downloads/) using your Adobe ID. You’ll be asked to accept the Adobe Developer Terms of Use before using them.
+To use the Adobe Clean font families, download them through the [Adobe Developer Console](https://developer.adobe.com/console/downloads/) using your Adobe ID. You’ll be asked to accept the Adobe Developer Terms of Use before using them.
 
 > **Caution:** Adobe Clean, Adobe Clean Serif, and Adobe Clean Han are [restricted fonts](https://www.adobe.com/products/type/font-licensing/restricted-fonts.html) for the exclusive use of Adobe products and software.
 

--- a/src/pages/resources/spectrum-intro/lesson2.md
+++ b/src/pages/resources/spectrum-intro/lesson2.md
@@ -65,7 +65,7 @@ Then include the Adobe Fonts, for example using your Typekit ID. To create one, 
 <script>window.Typekit.load()</script>
 ```
 
-Now you can start using components by copy/pasting their code from the [documentation](http://opensource.adobe.com/spectrum-css/).
+Now you can start using components by copy/pasting their code from the [documentation](https://opensource.adobe.com/spectrum-css/).
 In this example, we'll use these components: 
 
 * [Heading](https://opensource.adobe.com/spectrum-css/components/typography-heading/)

--- a/src/pages/resources/spectrum-intro/lesson2.md
+++ b/src/pages/resources/spectrum-intro/lesson2.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 2: Spectrum CSS'
+description: 'Use Spectrum CSS to build a simple form with Spectrum''s typography and text-field components.'
 ---
 
 # Lesson 2: Spectrum CSS

--- a/src/pages/resources/spectrum-intro/lesson2.md
+++ b/src/pages/resources/spectrum-intro/lesson2.md
@@ -69,11 +69,13 @@ Then include the Adobe Fonts, for example using your Typekit ID. To create one, 
 Now you can start using components by copy/pasting their code from the [documentation](https://opensource.adobe.com/spectrum-css/).
 In this example, we'll use these components: 
 
-* [Heading](https://opensource.adobe.com/spectrum-css/components/typography-heading/)
-* [Form](https://opensource.adobe.com/spectrum-css/components/form/)
-* [CTA Button](https://opensource.adobe.com/spectrum-css/components/button-cta/)
-* [Textfield](https://opensource.adobe.com/spectrum-css/components/textfield/)
-* [Checkbox](https://opensource.adobe.com/spectrum-css/components/checkbox/)
+* Heading
+* Form
+* CTA Button
+* Textfield
+* Checkbox
+
+Browse the components and copy their code from the [Spectrum CSS documentation](https://opensource.adobe.com/spectrum-css/).
 
 This results in the following code: 
 

--- a/src/pages/resources/spectrum-intro/lesson3.md
+++ b/src/pages/resources/spectrum-intro/lesson3.md
@@ -72,7 +72,7 @@ ReactDOM.render(
 
 Provider is the containing component that all other React Spectrum components are the children of. The Provider's theme is the CSS variable set for colorScheme and scale values.
 
-Consult the [React documentation](https://react-spectrum.adobe.com/docs/react-spectrum/Provider.html) for more details.
+Consult the [React documentation](https://react-spectrum.adobe.com/v3/Provider.html) for more details.
 
 > **Note**: A Typekit ID is required to use the suggested Adobe fonts. Visit [Adobe Fonts](https://fonts.adobe.com/?ref=tk.com) to create one. The default font is intended only for prototyping work.
 

--- a/src/pages/resources/spectrum-intro/lesson3.md
+++ b/src/pages/resources/spectrum-intro/lesson3.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 3: React Spectrum'
+description: 'Use the React Spectrum component library to build accessible, internationalized UI from Spectrum components.'
 ---
 
 # Lesson 3: React Spectrum

--- a/src/pages/resources/spectrum-intro/lesson3.md
+++ b/src/pages/resources/spectrum-intro/lesson3.md
@@ -19,7 +19,7 @@ React Spectrum is composed of three parts:
 
 React Spectrum enables accessibility and common behavior to be handled out of the box. Using it saves front-end development time, so you can focus on styling and other design-specific features that can be built on top of the library.
 
-If you're not familiar with React, please read the [React getting started guide](https://reactjs.org/docs/getting-started.html). 
+If you're not familiar with React, please read the [React getting started guide](https://react.dev/learn). 
 
 > Note: these documents, and this tutorial, refer to the legacy version of React. The sample project should work as indicated.
 

--- a/src/pages/resources/spectrum-intro/lesson4.md
+++ b/src/pages/resources/spectrum-intro/lesson4.md
@@ -22,7 +22,7 @@ You'll see several options for your app to include, such as serverless actions, 
 
 ## Single-Page application
 
-This will generate a single-page application project using [React](https://reactjs.org/) and [Experience Cloud Shell](../../guides/app_builder_guides/exc_app/aec-integration.md) utilities to integrate the SPA within the Adobe Experience Cloud.
+This will generate a single-page application project using [React](https://react.dev/) and [Experience Cloud Shell](../../guides/app_builder_guides/exc_app/aec-integration.md) utilities to integrate the SPA within the Adobe Experience Cloud.
 The best ways to use Experience Shell (for example, routing) will be covered in another Code Lab.
 
 App Builder SPAs follow [JAMstack principles](https://jamstack.org/): "Fast and secure apps delivered by pre-rendering files and serving them directly from a Content Delivery Network." 

--- a/src/pages/resources/spectrum-intro/lesson4.md
+++ b/src/pages/resources/spectrum-intro/lesson4.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 4: React Spectrum in App Builder'
+description: 'Build a React Spectrum App Builder single-page application using the aio CLI standalone template.'
 ---
 
 # Lesson 4: React Spectrum in App Builder

--- a/src/pages/resources/spectrum-intro/requirements.md
+++ b/src/pages/resources/spectrum-intro/requirements.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Requirements
+description: 'Environment requirements for the Spectrum and React Spectrum App Builder Code Lab.'
 ---
 
 <Fragment src="../transclusions/requirements.md"/>

--- a/src/pages/resources/spectrum-intro/welldone.md
+++ b/src/pages/resources/spectrum-intro/welldone.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Well done
+description: 'Recap of the Spectrum Code Lab and the App Builder design-system skills you learned.'
 ---
 
 # Well Done

--- a/src/pages/resources/todo-app/lesson1.md
+++ b/src/pages/resources/todo-app/lesson1.md
@@ -4,7 +4,7 @@ keywords:
   - Extensibility
   - API Documentation
   - Developer Tooling
-title: 'Lesson 1: Create a New App Builder App with the React Spectrum template'
+title: 'Lesson 1: Create an App with the React Spectrum template'
 ---
 
 # Lesson 1: Create a New App Builder App using the React Spectrum template

--- a/src/pages/resources/todo-app/lesson1.md
+++ b/src/pages/resources/todo-app/lesson1.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 1: Create an App with the React Spectrum template'
+description: 'Create an App Builder application using the React Spectrum template for the to-do app Code Lab.'
 ---
 
 # Lesson 1: Create a New App Builder App using the React Spectrum template

--- a/src/pages/resources/todo-app/lesson2.md
+++ b/src/pages/resources/todo-app/lesson2.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 2: Setup Runtime actions'
+description: 'Set up Runtime actions to handle CRUD operations for to-do lists in an App Builder application.'
 ---
 
 # Lesson 2: Set up Runtime Actions

--- a/src/pages/resources/todo-app/lesson3.md
+++ b/src/pages/resources/todo-app/lesson3.md
@@ -12,7 +12,7 @@ title: 'Lesson 3: Setup the CreateTodoList component'
 In this lesson, we'll create a first React component that will be used to perform a create operation to generate a to-do list. The only value that will be passed to create a to-do list is its name.
 
 First, we'll create the React component file under `web-src/src/components/` and name it `CreateTodoList.js`. 
-If you're not familiar with React components and props, please first read the React documentation on [JSX](https://reactjs.org/docs/introducing-jsx.html) and [Components and props](https://reactjs.org/docs/components-and-props.html).
+If you're not familiar with React components and props, please first read the React documentation on [JSX](https://legacy.reactjs.org/docs/introducing-jsx.html) and [Components and props](https://legacy.reactjs.org/docs/components-and-props.html).
 
 > Note: these documents, and this tutorial, refer to the legacy version of React. The sample project should work as indicated.
 
@@ -22,10 +22,10 @@ If you choose the React Spectrum template, the App Builder app will have `@adobe
 
 This component will make use of several React Spectrum components: 
 
-* [Flex](https://react-spectrum.adobe.com/react-spectrum/Flex.html) for the layout.
-* [Form](https://react-spectrum.adobe.com/react-spectrum/Form.html) to submit the todo list.
-* [TextField](https://react-spectrum.adobe.com/react-spectrum/TextField.html) as the main input field.
-* [Button](https://react-spectrum.adobe.com/react-spectrum/Button.html) to trigger form submission.
+* [Flex](https://react-spectrum.adobe.com/v3/Flex.html) for the layout.
+* [Form](https://react-spectrum.adobe.com/v3/Form.html) to submit the todo list.
+* [TextField](https://react-spectrum.adobe.com/v3/TextField.html) as the main input field.
+* [Button](https://react-spectrum.adobe.com/v3/Button.html) to trigger form submission.
 
 We can import them all with a single statement:
 
@@ -45,9 +45,9 @@ function CreateTodoList({ onCreate }) {
 
 ## Creating a to-do list
 
-We'll declare a state variable and bind it to the Textfield in order to retrieve the input value. If you're not familiar with React hooks, please read the [hooks introduction](https://reactjs.org/docs/hooks-intro.html).
+We'll declare a state variable and bind it to the Textfield in order to retrieve the input value. If you're not familiar with React hooks, please read the [hooks introduction](https://legacy.reactjs.org/docs/hooks-intro.html).
 
-First, we have to import the [State Hook](https://reactjs.org/docs/hooks-state.html) `useState` from `react` before being able to define a state variable:
+First, we have to import the [State Hook](https://legacy.reactjs.org/docs/hooks-state.html) `useState` from `react` before being able to define a state variable:
 
 ```javascript
 import { useState } from 'react';
@@ -59,10 +59,10 @@ Calling `useState` will return an `array` with two values: the state value and a
 const [todoListName, setTodoListName] = useState('');
 ```
 
-We're using a [destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) to retrieve and declare both values. On initialization, the value of `todoListName` is set to empty string `''` by default.
+We're using a [destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring) to retrieve and declare both values. On initialization, the value of `todoListName` is set to empty string `''` by default.
 
 Next we'll bind the `todoListName` state to the TextField value and update it with `setTodoListName()` on every input change. 
-Learn more about React event handling [here](https://reactjs.org/docs/handling-events.html).
+Learn more about React event handling [here](https://legacy.reactjs.org/docs/handling-events.html).
 
 ```jsx
 <TextField
@@ -92,7 +92,7 @@ We'll wrap the `TextField` and submit `Button` with a `Form` component so that w
 ## The full component
 
 Finally, we'll add the Flex layout to align the TextField with the Button to obtain a fully functional React component.
-Read more about React rendering [here](https://reactjs.org/docs/rendering-elements.html).
+Read more about React rendering [here](https://legacy.reactjs.org/docs/rendering-elements.html).
 
 See the full component code [here](https://github.com/AdobeDocs/adobeio-samples-todoapp/blob/master/web-src/src/components/CreateTodoList.js).
 

--- a/src/pages/resources/todo-app/lesson3.md
+++ b/src/pages/resources/todo-app/lesson3.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 3: Setup the CreateTodoList component'
+description: 'Build the CreateTodoList React component using React Spectrum Form, TextField, and Button components.'
 ---
 
 # Lesson 3: Setup the CreateTodoList component

--- a/src/pages/resources/todo-app/lesson4.md
+++ b/src/pages/resources/todo-app/lesson4.md
@@ -9,7 +9,7 @@ title: 'Lesson 4: Setup the Todo component'
 
 # Lesson 4: Setup the Todo component
 
-In this lesson, we'll create a Todo React component composed of only two React Spectrum components: [Checkbox](https://react-spectrum.adobe.com/react-spectrum/Checkbox.html) and [TextField](https://react-spectrum.adobe.com/react-spectrum/TextField.html).
+In this lesson, we'll create a Todo React component composed of only two React Spectrum components: [Checkbox](https://react-spectrum.adobe.com/v3/Checkbox.html) and [TextField](https://react-spectrum.adobe.com/v3/TextField.html).
 
 In a way similar to [lesson 3](lesson3.md), we'll create the React component file under `web-src/src/components/` and name it `Todo.js`.
 
@@ -17,9 +17,9 @@ In a way similar to [lesson 3](lesson3.md), we'll create the React component fil
 
 This component will make use of several React Spectrum components: 
 
-* [Flex](https://react-spectrum.adobe.com/react-spectrum/Flex.html) for the layout.
-* [TextField](https://react-spectrum.adobe.com/react-spectrum/TextField.html) the input field for the todo value.
-* [Checkbox](https://react-spectrum.adobe.com/react-spectrum/Checkbox.html) to check a todo which is done.
+* [Flex](https://react-spectrum.adobe.com/v3/Flex.html) for the layout.
+* [TextField](https://react-spectrum.adobe.com/v3/TextField.html) the input field for the todo value.
+* [Checkbox](https://react-spectrum.adobe.com/v3/Checkbox.html) to check a todo which is done.
 
 ```javascript
 import { Flex, Checkbox, TextField } from '@adobe/react-spectrum';
@@ -41,7 +41,7 @@ function Todo({ name, todo, onUpdate }) {
 
 ## Updating a to-do item
 
-Again, we're going to use the [State hook](https://reactjs.org/docs/hooks-state.html) `useState` to declare two state variables, bind one to the Checkbox and the other to the Textfield:
+Again, we're going to use the [State hook](https://legacy.reactjs.org/docs/hooks-state.html) `useState` to declare two state variables, bind one to the Checkbox and the other to the Textfield:
 
 ```javascript
 const [value, setValue] = useState(todo.value);

--- a/src/pages/resources/todo-app/lesson4.md
+++ b/src/pages/resources/todo-app/lesson4.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 4: Setup the Todo component'
+description: 'Build the Todo React component using React Spectrum Checkbox and TextField components.'
 ---
 
 # Lesson 4: Setup the Todo component

--- a/src/pages/resources/todo-app/lesson5.md
+++ b/src/pages/resources/todo-app/lesson5.md
@@ -21,14 +21,14 @@ We'll create the React component file under `web-src/src/components/` and name i
 
 This component will make use of several React Spectrum components: 
 
-* [View](https://react-spectrum.adobe.com/react-spectrum/View.html) a generic container.
-* [Well](https://react-spectrum.adobe.com/react-spectrum/Well.html) a generic pre-styled container which will contain the todo list.
-* [Flex](https://react-spectrum.adobe.com/react-spectrum/Flex.html) for the layout.
-* [Form](https://react-spectrum.adobe.com/react-spectrum/Form.html) to submit the todo.
-* [TextField](https://react-spectrum.adobe.com/react-spectrum/TextField.html) the input field for the todo value.
-* [ActionButton](https://react-spectrum.adobe.com/react-spectrum/ActionButton.html) to trigger form submission.
-* [AlertDialog](https://react-spectrum.adobe.com/react-spectrum/AlertDialog.html) to warn the user before deleting a todo list.
-* [DialogTrigger](https://react-spectrum.adobe.com/react-spectrum/DialogTrigger.html) to open the AlertDialog.
+* [View](https://react-spectrum.adobe.com/v3/View.html) a generic container.
+* [Well](https://react-spectrum.adobe.com/v3/Well.html) a generic pre-styled container which will contain the todo list.
+* [Flex](https://react-spectrum.adobe.com/v3/Flex.html) for the layout.
+* [Form](https://react-spectrum.adobe.com/v3/Form.html) to submit the todo.
+* [TextField](https://react-spectrum.adobe.com/v3/TextField.html) the input field for the todo value.
+* [ActionButton](https://react-spectrum.adobe.com/v3/ActionButton.html) to trigger form submission.
+* [AlertDialog](https://react-spectrum.adobe.com/v3/AlertDialog.html) to warn the user before deleting a todo list.
+* [DialogTrigger](https://react-spectrum.adobe.com/v3/DialogTrigger.html) to open the AlertDialog.
 
 ```javascript
 import { View, Flex, Form, TextField, ActionButton, AlertDialog, DialogTrigger, Well } from '@adobe/react-spectrum';
@@ -51,7 +51,7 @@ function TodoList({ todoList, onDelete, onUpdate }) {
 
 ## Spectrum Icons
 
-We'll add [React Spectrum Workflow Icons](https://react-spectrum.adobe.com/react-spectrum/workflow-icons.html) to the `TodoList` component. The icons are simply SVGs packed as React components.  
+We'll add [React Spectrum Workflow Icons](https://react-spectrum.adobe.com/v3/workflow-icons.html) to the `TodoList` component. The icons are simply SVGs packed as React components.  
 
 To import icons, you need the `@spectrum-icons/workflow` dependency. It's pre-installed if you initialize the App Builder app with the React Spectrum template.
 
@@ -90,7 +90,7 @@ Now you can use Spectrum CSS Heading classes to render the to-do list name.
 
 ## Rendering to-do items
 
-Once again, we're going to use the [State hook](https://reactjs.org/docs/hooks-state.html) `useState` to declare a state variable which will hold a list of to-do items. This list will be updated whenever a new to-do item is created. By default, it's initialized with the `todos` from the `todoList` prop: 
+Once again, we're going to use the [State hook](https://legacy.reactjs.org/docs/hooks-state.html) `useState` to declare a state variable which will hold a list of to-do items. This list will be updated whenever a new to-do item is created. By default, it's initialized with the `todos` from the `todoList` prop: 
 
 ```javascript
 const [todoItems, setTodoItems] = useState(todos);
@@ -106,7 +106,7 @@ Next we'll iterate over the `todoItems` array using the [map()](https://develope
 </View>
 ```
 
-The `key` property is necessary in React to uniquely identify the to-do item. In this case, we use the todo id. You can read more about React lists and keys [here](https://reactjs.org/docs/lists-and-keys.html).
+The `key` property is necessary in React to uniquely identify the to-do item. In this case, we use the todo id. You can read more about React lists and keys [here](https://legacy.reactjs.org/docs/lists-and-keys.html).
 
 We're also passing the `name`, `todo` and `onUpdate` props down to the `Todo` component.      
 
@@ -118,7 +118,7 @@ In [lesson 2](lesson2.md), we defined a `MAX_TODO_ITEMS` value within a global c
 import { MAX_TODO_ITEMS } from '../../defaults.json';
 ```
 
-Now we'll use the [React hook](https://reactjs.org/docs/hooks-intro.html) `useState` again to bind it to the TextField to create a new to-do item the way we did in the previous lesson: 
+Now we'll use the [React hook](https://legacy.reactjs.org/docs/hooks-intro.html) `useState` again to bind it to the TextField to create a new to-do item the way we did in the previous lesson: 
 
 ```javascript
 const [newTodo, setNewTodo] = useState('');

--- a/src/pages/resources/todo-app/lesson5.md
+++ b/src/pages/resources/todo-app/lesson5.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 5: Setup the TodoList component'
+description: 'Build the TodoList React component to create, delete, and display to-do items in an App Builder application.'
 ---
 
 # Lesson 5: Set up the TodoList component

--- a/src/pages/resources/todo-app/lesson6.md
+++ b/src/pages/resources/todo-app/lesson6.md
@@ -29,13 +29,13 @@ import { TodoList } from './TodoList';
 
 This component will make use of several React Spectrum components:
 
-* [Provider](https://react-spectrum.adobe.com/react-spectrum/Provider.html), the container of the React Spectrum application.
-* [defaultTheme](https://react-spectrum.adobe.com/react-spectrum/theming.html), the default React Spectrum theme.
-* [ProgressCircle](https://react-spectrum.adobe.com/react-spectrum/ProgressCircle.html), the loading indicator.
-* [View](https://react-spectrum.adobe.com/react-spectrum/View.html), a generic container.
-* [Flex](https://react-spectrum.adobe.com/react-spectrum/Flex.html), for the layout of the loading indicator.
-* [Grid](https://react-spectrum.adobe.com/react-spectrum/Grid.html), for the layout of the todo lists.
-* [Repeat](https://react-spectrum.adobe.com/react-spectrum/Grid.html#repeat), a helper function for Grid.
+* [Provider](https://react-spectrum.adobe.com/v3/Provider.html), the container of the React Spectrum application.
+* [defaultTheme](https://react-spectrum.adobe.com/v3/theming.html), the default React Spectrum theme.
+* [ProgressCircle](https://react-spectrum.adobe.com/v3/ProgressCircle.html), the loading indicator.
+* [View](https://react-spectrum.adobe.com/v3/View.html), a generic container.
+* [Flex](https://react-spectrum.adobe.com/v3/Flex.html), for the layout of the loading indicator.
+* [Grid](https://react-spectrum.adobe.com/v3/Grid.html), for the layout of the todo lists.
+* [Repeat](https://react-spectrum.adobe.com/v3/Grid.html), a helper function for Grid.
 
 ```javascript
 import { Provider, defaultTheme, View, Flex, Grid, repeat, ProgressCircle } from '@adobe/react-spectrum';
@@ -53,7 +53,7 @@ function App({ ims }) {
 
 ## Component state values
 
-On initialization, the App will display a loading indicator while fetching the todo lists. For the loading indicator and the to-do lists, we'll use the [State hook](https://reactjs.org/docs/hooks-state.html) `useState` again.   
+On initialization, the App will display a loading indicator while fetching the todo lists. For the loading indicator and the to-do lists, we'll use the [State hook](https://legacy.reactjs.org/docs/hooks-state.html) `useState` again.   
 
 ```javascript
 const [isLoading, setIsLoading] = useState(true);
@@ -118,7 +118,7 @@ const onUpdateTodoList = async (name, todo) => {
 
 ## Loading indicator
 
-By default, we'll be showing a `ProgressCircle` to indicate that the App is loading.  Meanwhile, the to-do lists will be fetched using an [Effect Hook](https://reactjs.org/docs/hooks-effect.html) which will run only once when the App is mounted.    
+By default, we'll be showing a `ProgressCircle` to indicate that the App is loading.  Meanwhile, the to-do lists will be fetched using an [Effect Hook](https://legacy.reactjs.org/docs/hooks-effect.html) which will run only once when the App is mounted.    
 
 Once we've retrieved the to-do lists, well update the to-do list state and set the loading state to `false`:
 
@@ -134,7 +134,7 @@ useEffect(() => {
 }, []);
 ```
 
-With React [Conditional Rendering](https://reactjs.org/docs/conditional-rendering.html), we can easily define what will be rendered based on the `isLoading` state. Once the state value is set to `false`, we'll display the `CreateTodoList` from [lesson 3](lesson3.md) and pass the `onCreateTodoList` callback function as prop:   
+With React [Conditional Rendering](https://legacy.reactjs.org/docs/conditional-rendering.html), we can easily define what will be rendered based on the `isLoading` state. Once the state value is set to `false`, we'll display the `CreateTodoList` from [lesson 3](lesson3.md) and pass the `onCreateTodoList` callback function as prop:   
 
 ```jsx
 <View elementType="main" minHeight="100vh">

--- a/src/pages/resources/todo-app/lesson6.md
+++ b/src/pages/resources/todo-app/lesson6.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: 'Lesson 5: Bringing the pieces together to build the App'
+description: 'Assemble the React Spectrum components and Runtime actions into a complete to-do list App Builder application.'
 ---
 
 # Lesson 5: Assembling the Pieces to Build the App

--- a/src/pages/resources/todo-app/requirements.md
+++ b/src/pages/resources/todo-app/requirements.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Requirements
+description: 'Environment requirements for the to-do app React Spectrum App Builder Code Lab.'
 ---
 
 <Fragment src="../transclusions/requirements.md"/>

--- a/src/pages/resources/todo-app/welldone.md
+++ b/src/pages/resources/todo-app/welldone.md
@@ -5,6 +5,7 @@ keywords:
   - API Documentation
   - Developer Tooling
 title: Well done
+description: 'Recap of the to-do app Code Lab and the React Spectrum App Builder skills you learned.'
 ---
 
 # Well Done

--- a/src/pages/resources/transclusions/requirements.md
+++ b/src/pages/resources/transclusions/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: Requirements
+description: 'Shared environment requirements and skills prerequisites for App Builder Code Labs.'
 ---
 
 # Requirements

--- a/src/pages/resources/videos/developers-live/extend-experience-cloud.md
+++ b/src/pages/resources/videos/developers-live/extend-experience-cloud.md
@@ -1,5 +1,5 @@
 ---
-title: Adobe Developers Live | So you want to extend Adobe Experience Cloud?
+title: 'Developers Live: Extend Adobe Experience Cloud'
 description: You want to extend Adobe solutions using a modern architecture that works for multiple solutions? Well, we think that you should give App Builder a try. 
 keywords:
   - Adobe I/O

--- a/src/pages/resources/videos/exploring/ci-cd.md
+++ b/src/pages/resources/videos/exploring/ci-cd.md
@@ -1,6 +1,6 @@
 ---
 title: Exploring App Builder - CI/CD
-description: Manik Jindal, App Builder Product Manager, will dive into CI/CD. You'll learn how to set up Github CI/CD we include with App Builder. In addition, we'll cover how to setup  a custom CI/CD pipeline with your tool of choice. Bring your questions and the App Builder team will be happy to answer any and all after the presentation. 
+description: Manik Jindal explores CI/CD for App Builder, covering the bundled GitHub setup and custom pipelines with your tool of choice.
 keywords:
   - Adobe I/O
   - Extensibility

--- a/src/pages/resources/videos/exploring/custom-events.md
+++ b/src/pages/resources/videos/exploring/custom-events.md
@@ -1,6 +1,6 @@
 ---
 title: Exploring App Builder - Custom Events
-description: Join us as we dive deep into the topic of Adobe I/O Events including our new feature with App Builder - Custom Events. Kanika Gera, Sr Product Manager and Sangeetha Krishnan share everything you need to know about Adobe I/O Events and how they are used in App Builder applications. 
+description: A deep dive into Adobe I/O Events and the new Custom Events feature for App Builder, with PM Kanika Gera and Sangeetha Krishnan.
 keywords:
   - Adobe I/O
   - Extensibility

--- a/src/pages/resources/videos/exploring/dashboard-case-study.md
+++ b/src/pages/resources/videos/exploring/dashboard-case-study.md
@@ -4,7 +4,8 @@ keywords:
   - Adobe I/O
   - Extensibility
   - API Documentation
-  - Developer Tooling  
+  - Developer Tooling
+description: 'Exploring App Builder video walking through a dashboard case study built on App Builder.'
 ---
 
 # Exploring App Builder - Dashboard Case Study

--- a/src/pages/resources/videos/exploring/live-wired-sneak.md
+++ b/src/pages/resources/videos/exploring/live-wired-sneak.md
@@ -1,6 +1,6 @@
 ---
 title: Exploring App Builder - Live Wired Sneak
-description: Join us for a very special Adobe Summit edition of Office Hours. Ron, Alex and Dave will go behind the scenes to show how they brought to life a no code future for building React Spectrum UI for App Builder apps. If you watched Adobe Summit sneaks be sure to see how the app works and talk about this exciting new development! Bring your questions and the App Builder team will be happy to answer any and all after the presentation.  
+description: An Adobe Summit edition of Office Hours where Ron, Alex, and Dave show the no-code future for building React Spectrum UI in App Builder.
 keywords:
   - Adobe I/O
   - Extensibility

--- a/src/pages/resources/videos/exploring/ode-case-study.md
+++ b/src/pages/resources/videos/exploring/ode-case-study.md
@@ -4,7 +4,8 @@ keywords:
   - Adobe I/O
   - Extensibility
   - API Documentation
-  - Developer Tooling  
+  - Developer Tooling
+description: 'Exploring App Builder video walking through an ODE (Open Data Event) case study built on App Builder.'
 ---
 
 # Exploring App Builder - ODE Case Study

--- a/src/pages/resources/videos/exploring/projects-and-workspaces.md
+++ b/src/pages/resources/videos/exploring/projects-and-workspaces.md
@@ -1,6 +1,6 @@
 ---
 title: Exploring App Builder - Projects and Workspaces
-description: The App Builder team shared a short presentation about projects and workspaces and how to use customizations to help your team collaborate on building App Builder Applications.  
+description: A short presentation on projects and workspaces and how to use customizations to collaborate on App Builder applications.
 keywords:
   - Adobe I/O
   - Extensibility

--- a/src/pages/resources/videos/exploring/react-spectrum.md
+++ b/src/pages/resources/videos/exploring/react-spectrum.md
@@ -1,6 +1,6 @@
 ---
 title: Exploring App Builder - React Spectrum
-description: We are joined by Rob Snow from the React Spectrum team to learn about React Spectrum, how to get started using it and how to get involved in their open source project. After Rob's presentation, stick around as we answer questions from our community.  
+description: Rob Snow from the React Spectrum team explains how to get started with React Spectrum and how to get involved in the open source project.
 keywords:
   - Adobe I/O
   - Extensibility

--- a/src/pages/resources/videos/index.md
+++ b/src/pages/resources/videos/index.md
@@ -4,7 +4,8 @@ keywords:
   - Adobe I/O
   - Extensibility
   - API Documentation
-  - Developer Tooling  
+  - Developer Tooling
+description: 'Index of App Builder tech talks, deep-dive sessions, and partner use case videos.'
 ---
 
 # App Builder Tech Talks, Deep Dive Sessions and Partner Use Cases

--- a/src/pages/resources/videos/index.md
+++ b/src/pages/resources/videos/index.md
@@ -1,5 +1,5 @@
 ---
-title: App Builder Tech Talks, Deep Dive Sessions and Partner Use Cases     
+title: 'App Builder: Tech Talks and Partner Use Cases'
 keywords:
   - Adobe I/O
   - Extensibility

--- a/src/pages/resources/videos/overview/architecture.md
+++ b/src/pages/resources/videos/overview/architecture.md
@@ -4,7 +4,8 @@ keywords:
   - Adobe I/O
   - Extensibility
   - API Documentation
-  - Developer Tooling  
+  - Developer Tooling
+description: 'Video walkthrough of App Builder''s architecture and how its components work together.'
 ---
 
 # A Breakdown of App Builder's Architecture

--- a/src/pages/resources/videos/overview/e2-e-user-journey.md
+++ b/src/pages/resources/videos/overview/e2-e-user-journey.md
@@ -4,7 +4,8 @@ keywords:
   - Adobe I/O
   - Extensibility
   - API Documentation
-  - Developer Tooling  
+  - Developer Tooling
+description: 'Video walkthrough of the end-to-end user journey for App Builder developers and end users.'
 ---
 
 # Following the End-to-End User Journey

--- a/src/pages/resources/videos/overview/getting-started.md
+++ b/src/pages/resources/videos/overview/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: App Builder - Getting Started
-description: In this video, we will cover how to setup your project in the Adobe Developer Console, init the code, review the project structure, test, and play with the working code.  
+description: Set up your project in Developer Console, initialize the code, review the structure, and test the working app.
 keywords:
   - Adobe I/O
   - Extensibility

--- a/src/pages/resources/videos/overview/introduction.md
+++ b/src/pages/resources/videos/overview/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introducing App Builder
-description: This App Builder tech talk aims to explore what’s possible with App Builder as well as answer questions from our customers & partners.  Join us to learn more about how App Builder enables you to build cloud native applications to empower your employees. You’ll learn about common use cases as well as a peek on how to get started building with App Builder.  
+description: Tech talk on what's possible with App Builder, common use cases, and how to start building cloud-native apps for your employees.
 keywords:
   - Adobe I/O
   - Extensibility

--- a/src/pages/resources/videos/overview/security.md
+++ b/src/pages/resources/videos/overview/security.md
@@ -4,7 +4,8 @@ keywords:
   - Adobe I/O
   - Extensibility
   - API Documentation
-  - Developer Tooling  
+  - Developer Tooling
+description: 'Video walkthrough of the App Builder security model, authentication, and authorization.'
 ---
 
 # A Full Security Overview


### PR DESCRIPTION
## Summary

Repo-wide cleanup that takes the lint warning count from **428 → ~127** (a 70% reduction). The remaining warnings are all dead-URL false positives where the URL works in browsers but Adobe/Twitter/Medium/GitHub bot protection blocks the linter's automated check.

195 files touched, 721 insertions / 179 deletions. All changes scoped to `src/pages/`.

## What was fixed

| Category | Baseline | Fixed | Notes |
|---|---|---|---|
| Redirecting URLs | 109 | 109 | Swapped to each linter-supplied "expected final URL". All replacements re-verified live with `curl`. |
| Description too long | 11 | 11 | Rewritten to under 160 chars. |
| Title too long | 7 | 7 | Rewritten to under 60 chars. |
| Missing top-level title | 1 | 1 | `development.md`. |
| Missing description (existing frontmatter) | 133 | 133 | One-line summary per file, derived from the file's intro paragraph and H1. |
| Missing frontmatter entirely | 40 | 40 | Added `keywords` / `title` / `description` blocks. Includes stripping a malformed pseudo-codefence from `how-runtime-works.md`. |
| Duplicate H1 | 7 | 7 | Collapsed exact duplicates, demoted secondary H1s to H2. |
| Missing image alt text | 15 | 15 | Descriptive alt text based on filename + surrounding context. |
| Dead URLs | 105 | ~21 | 16 unique truly-dead URLs replaced or reworded. ~84 remaining warnings are false positives. |

## Notable dead-URL fixes (worth a sanity check)

Each of these required a judgment call — every replacement URL was verified live with `curl` before commit:

- `developer.adobe.com/runtime/.../howitworks_f01.png` → local `../../images/howitworks_f01.png` in `how-runtime-works.md`
- `developer.adobe.com/developer-distribution/.../discoverandmanage/#discover` + `#acquire` → collapsed to single parent link in `distribution.md`
- `github.com/adobe/aio-cli-plugin-app-storage/tree/epic/abdb-implementation` → repo root in `db-commands.md`
- `developer.adobe.com/firefly-services/.../photoshop_removeBackground/` → parent `…/api/` in `lesson3.md`
- `developer.adobe.com/events/docs/guides/api/journaling_api/` → `…/api/` parent in `lesson4.md`, `journaling-events/index.md`
- 5 × `opensource.adobe.com/spectrum-css/components/*` → reworded into a plain component list pointing at the Storybook root (`spectrum-intro/lesson2.md`). **Worth a second look** — if Storybook has per-component anchors, re-linking would be nicer.
- `react-spectrum.adobe.com/react-spectrum/Provider.html` → `…/v3/Provider.html`
- `io-webhook.herokuapp.com/` → reworded to point at webhook.site
- `crontab.org` (x2) → `crontab.guru`
- Epsagon links → reworded paragraph noting that Epsagon was acquired and its docs are no longer available. **Worth a second look** — you may prefer to drop the mention entirely rather than reference a defunct product.
- 3 × `developer-console/docs/guides//guides/...` → fixed the duplicated `/guides/` segment in `first-app.md`

No truly-dead URLs were silently deleted; every removal was replaced with a working parent URL or a paraphrase that still reads naturally.

## Relationship to other open PRs

- **#566** (Admin Console product profile docs): independent, no conflict.
- **#567** (smaller set-up.md lint fix): partially superseded by this PR — the `description` shortening and the `solutionpartners.adobe.com` redirect are now in this PR with slightly different wording. The inquirer npm-URL swap in #567 is not in this PR (the npm URLs are bot-blocked false positives, similar to helpx). Recommend closing #567 once this lands.

## Test plan

- [ ] Re-run the Lint workflow on this PR and confirm the warning count is ~127 (down from 428).
- [ ] Spot-check the rendered pages for files where descriptions/titles were rewritten (the 144 frontmatter edits — mostly under `get_started/runtime_getting_started/` and `guides/runtime_guides/`).
- [ ] Visual sanity-check the three judgment-call rewrites flagged above (Spectrum CSS component list, Epsagon paragraph, distribution.md discover/acquire collapse).