### PR TITLE
docs: add Node.js 26 to supported runtimes reference

### DIFF
--- a/src/pages/guides/runtime_guides/reference_docs/runtimes.md
+++ b/src/pages/guides/runtime_guides/reference_docs/runtimes.md
@@ -4,6 +4,15 @@ Adobe I/O Runtime supports the three latest Node.js versions (see the [Node.js r
 
 These npm modules (and their dependencies) are pre-installed, so you don't need to package them with your action code to use them:
 
+### Node.js v26.1.0
+
+    "express": "4.22.2",
+    "openwhisk": "3.21.9",
+    "body-parser": "1.20.5",
+    "redis": "4.7.1",
+    "dnscache": "1.0.2",
+    "prom-client": "14.2.0"
+
 ### Node.js v24.0.1
 
     "express": "4.18.2",
@@ -74,12 +83,13 @@ aio rt:action:create actionName fromFile.js --kind nodejs:22
 
 These images are on Docker Hub:
 
-1. [Node 24](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v24/tags)
-2. [Node 22](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v22/tags)
-3. [Node 20](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v20/tags)
-4. [Node 18](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v18/tags)
-5. [Node 16](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v16/tags)
-6. [Node 14](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v14/tags)
+1. [Node 26](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v26/tags)
+2. [Node 24](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v24/tags)
+3. [Node 22](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v22/tags)
+4. [Node 20](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v20/tags)
+5. [Node 18](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v18/tags)
+6. [Node 16](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v16/tags)
+7. [Node 14](https://hub.docker.com/r/adobeapiplatform/adobe-action-nodejs-v14/tags)
 
 ## Next steps
 


### PR DESCRIPTION
## Description

Adds **Node.js v26.1.0** to the App Builder supported-runtimes reference at https://developer.adobe.com/app-builder/docs/guides/runtime_guides/reference_docs/runtimes.

## Related Issue

Internal tracking: ACNA-4589 (Node 26 docs / release notes), ACNA-4585 (Node 26 epic). No public GitHub issue.

## Motivation and Context

`@adobe/aio-lib-runtime` [7.4.0](https://github.com/adobe/aio-lib-runtime/releases/tag/7.4.0) was published advertising `nodejs:26` to all CLI/SDK users, so the App Builder runtime reference needs to match — otherwise users see the kind in the CLI but not in the docs.

Reference:

- Kind PR: https://git.corp.adobe.com/bladerunner/openwhisk-runtime-nodejs/pull/176
- Version-bump PR (release/3.0.45): https://git.corp.adobe.com/bladerunner/openwhisk-runtime-nodejs/pull/177
- Lib release: https://github.com/adobe/aio-lib-runtime/releases/tag/7.4.0

## How Has This Been Tested?

Docs-only PR. Module-version values cross-checked against the merged `core/nodejs26Action/package.json` in `bladerunner/openwhisk-runtime-nodejs`.

Prod parity for `nodejs:26` was verified end-to-end before this PR:

- `https://adobeioruntime.net` lists `nodejs:26` with image `bladerunner/adobe-action-nodejs-v26:3.0.45`
- `aio app deploy` succeeds with `kind: nodejs:26`; `aio rt action list` shows the action registered with the new kind

## Screenshots (if appropriate):

N/A — text-only addition to an existing reference page.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.