### PR TITLE
docs(telemetry): note agent invocation data and AIO_TELEMETRY_DISABLED

### DIFF
--- a/src/pages/guides/app_builder_guides/telemetry.md
+++ b/src/pages/guides/app_builder_guides/telemetry.md
@@ -26,6 +26,7 @@ The data collected includes:
 - Any flags used, but not the values of the flags 
 - How long each command ran, and whether it was successful
 - Information about the environment, including operating system, node version and CLI version
+- Whether the command was run by a person or an AI agent, and the agent's name
 
 ## What about secrets and sensitive data?
 
@@ -64,6 +65,8 @@ If you would like to turn telemetry off, simply run `aio telemetry off`
 Individual commands may be run with telemetry off by using the `--no-telemetry` flag, for example:
 
 `aio app info --no-telemetry`
+
+You can also set `AIO_TELEMETRY_DISABLED` to `true`, `1`, or `yes` to disable telemetry for a single run (handy in CI), without changing your saved setting.
 
 ## Show me the code
 


### PR DESCRIPTION
## Description

  Updates the telemetry guide to match the telemetry-next implementation, with two minimal, user-facing additions:

  - **What data is collected** — discloses that we record whether a command was run by a person or an AI agent, and the agent's name.
  - **How do I opt out** — documents the `AIO_TELEMETRY_DISABLED` env var (`true` / `1` / `yes`) to disable telemetry for a single run (e.g. in CI), without changing the saved setting.

  ## Related Issue

- [ACNA-4600
](https://jira.corp.adobe.com/browse/ACNA-4600)

## Motivation and Context

  The telemetry plugin now records invocation context (person vs. AI agent + agent name) and honors the `AIO_TELEMETRY_DISABLED` environment variable. Neither was reflected in the user-facing guide, so the "what
  we collect" disclosure was incomplete and the env-var opt-out was undocumented.

  ## How Has This Been Tested?

  Documentation-only change. Previewed the rendered Markdown to confirm the new list item and paragraph render correctly and the page structure is unchanged.

  ## Screenshots (if appropriate):

  ## Types of changes

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

  ## Checklist:

  - [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
  - [x] I have read the **CONTRIBUTING** document.
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.