### PR TITLE
Fix New Relic license key requirements

### DIFF
--- a/src/pages/guides/app_builder_guides/application_logging/new-relic.md
+++ b/src/pages/guides/app_builder_guides/application_logging/new-relic.md
@@ -23,54 +23,59 @@ This guide covers configuration of your App Builder application to forward logs 
 
 * The latest version of AIO CLI. Check by running `aio --version`; update by running `npm install -g @adobe/aio-cli`
 
+<InlineAlert variant="info" slots="text" />
+
+App Builder does not support creating a new New Relic license key. Before configuring log forwarding, obtain an existing `INGEST - LICENSE` key from your organization's New Relic account administrator.
+
 ## Identify the API key and base URI
 
-1. Log in to New Relic and navigate to the API keys screen. Pick the `INGEST - LICENSE` API key type you want to use and copy the `key` value for later use.
+1. Obtain an existing `INGEST - LICENSE` key from your organization's New Relic account administrator and copy the `key` value for later use.
 
-2. Depending on the region hosting your New Relic account, you must use the United States or Europe endpoint as a `base uri`. 
-   
-   If you don't know the region of your New Relic instance, check the browser URL of your New Relic home. 
-   
-   * If the URL begins with `https://one.newrelic.com/`, specify 
-     `https://log-api.newrelic.com/log/v1` as the URI
-   
-   * If it begins with `https://one.eu.newrelic.com/`, specify 
+   App Builder does not support creating a new New Relic license key. If your organization does not already have an appropriate key, contact your New Relic account administrator.
+
+1. Depending on the region hosting your New Relic account, you must use the United States or Europe endpoint as a `base uri`.
+
+   If you don't know the region of your New Relic instance, check the browser URL of your New Relic home.
+
+   * If the URL begins with `https://one.newrelic.com/`, specify `https://log-api.newrelic.com/log/v1` as the URI
+
+   * If it begins with `https://one.eu.newrelic.com/`, specify
      `https://log-api.eu.newrelic.com/log/v1`
 
 ## Set up log forwarding in App Builder
 
 1. From the command line, navigate to the App Builder project directory on your local machine.
 
-2. Run this command, and supplying values from previous steps:
-   
+2. Run this command, providing values from previous steps:
+
    ```terminal
    aio app config set log-forwarding
    ? select log forwarding destination: New Relic
    ? base URI: <base_uri>
    ? license key: <license_key>
    ```
-   
+
    The URI value must include the protocol (`https://`).
 
 3. Verify that the configuration change has taken effect:
-   
+
    ```terminal
    aio app config get log-forwarding
    ```
 
-4. Execute an action in your App Builder application workspace to generate logs.
+4. To generate logs, execute an action in your App Builder application workspace.
 
 5. Go to New Relic Home > Logs and run your query.
 
 6. If you don't see any logs in New Relic, check for log forwarding errors:
-   
+
    ```terminal
    aio app config get log-forwarding errors
    ```
 
 ## Next steps
 
-If you are unable to set up log forwarding using these procedures, please visit [Adobe Experience Leage App Builder Community](https://experienceleaguecommunities.adobe.com/t5/app-builder/ct-p/adobe-app-builder) for support.
+If you are unable to set up log forwarding using these procedures, visit [Adobe Experience League Built by Developers Community](https://experienceleaguecommunities.adobe.com/groups/built-by-developers-207) for support.
 
 Return to [Managing Application Logs](logging.md).
 


### PR DESCRIPTION
## Description

Clarifies the New Relic license key requirements in the [App Builder log forwarding guide](https://developer.adobe.com/app-builder/docs/guides/app_builder_guides/application_logging/new-relic):

- Adds an upfront info alert stating that App Builder does not support creating a new New Relic license key, and that an existing `INGEST - LICENSE` key must be obtained from the organization's New Relic account administrator.
- Rewrites step 1 under "Identify the API key and base URI" to reflect the same requirement, instead of instructing readers to create a key in New Relic.
- Updates the broken/outdated "Next steps" community support link to the current [Adobe Experience League Built by Developers Community](https://experienceleaguecommunities.adobe.com/groups/built-by-developers-207).
- Minor copy edits (wording, trailing whitespace) for consistency.

## Related Issue

IOEXT-2108

## Motivation and Context

The previous guide implied readers could self-service a New Relic license key, which App Builder does not support and could send users down an unsupported path. The guide now sets the correct expectation before configuration begins.

## How Has This Been Tested?

Reviewed the rendered Markdown for correctness; no code changes involved.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
